### PR TITLE
Base Proof Options on Data Integrity with Restrictions

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,8 +445,8 @@ The `type` property of the proof MUST be `DataIntegrityProof`.
 The `cryptosuite` property of the proof MUST be `bbs-2023`.
           </p>
           <p>
-The value of the `proofValue` property of the proof MUST be an BBS signature or
-BBS proof produced according to [[CFRG-BBS-SIGNATURE]] then serialized and encoded
+The value of the `proofValue` property of the proof MUST be a BBS signature or
+BBS proof produced according to [[CFRG-BBS-SIGNATURE]] that is serialized and encoded
 according to procedures in section <a href="#algorithms"></a>.
           </p>
         </section>

--- a/index.html
+++ b/index.html
@@ -427,6 +427,11 @@ and [[?MULTICODEC]].
           <h3>DataIntegrityProof</h3>
 
           <p>
+A proof contains the attributes specified in the
+<a href="https://www.w3.org/TR/vc-data-integrity/#proofs">Proofs section</a>
+of [[VC-DATA-INTEGRITY]] with the following restrictions.
+          </p>
+          <p>
 The `verificationMethod` property of the proof MUST be a URL.
 Dereferencing the `verificationMethod` MUST result in an object
 containing a `type` property with the value set to
@@ -438,15 +443,6 @@ The `type` property of the proof MUST be `DataIntegrityProof`.
           </p>
           <p>
 The `cryptosuite` property of the proof MUST be `bbs-2023`.
-          </p>
-          <p>
-The `created` property of the proof MUST be an [[XMLSCHEMA11-2]]
-formatted date string.
-          </p>
-          <p>
-The `proofPurpose` property of the proof MUST be a string, and MUST
-match the verification relationship expressed by the verification method
-`controller`.
           </p>
           <p>
 The value of the `proofValue` property of the proof MUST be an BBS signature or


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-bbs/issues/108 to ensure that the `created` proof option is OPTIONAL. It does this by referring to the VC Data Integrity specification for all proof options and only mentioning proof options explicitly where their values are in some way restricted. This keeps this specification better align with VC Data Integrity as well as resolving the issue.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 502 Bad Gateway :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 2, 2024, 4:45 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2FWind4Greg%2Fvc-di-bbs%2F2bf7207276d23249464e509ead73a3371671b75c%2Findex.html%3FisPreview%3Dtrue)

```
error code: 502
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/vc-di-bbs%23116.)._
</details>
