### PR TITLE
Remove copy and paste errors wrt ECDSA-SD header values.

### DIFF
--- a/index.html
+++ b/index.html
@@ -613,7 +613,7 @@ bytes `0xd9`, `0x5d`, and `0x02`, and throw an error if it does not.
             </li>
             <li>
 Initialize `components` to an array that is the result of CBOR-decoding the
-bytes that follow the three-byte ECDSA-SD base proof header. Ensure the result
+bytes that follow the three-byte BBS base proof header. Ensure the result
 is an array of three elements.
             </li>
             <li>
@@ -901,7 +901,7 @@ Initialize `decodedProofValue` to the result of base64url-no-pad-decoding the
 substring that follows the leading `u` in `proofValue`.
             </li>
             <li>
-Ensure that the `decodedProofValue` starts with the ECDSA-SD disclosure proof
+Ensure that the `decodedProofValue` starts with the BBS disclosure proof
 header bytes `0xd9`, `0x5d`, and `0x03`, and throw an error if it does not.
             </li>
 <!-- [bbsProof, labelMapCompressed, mandatoryIndexes, adjSelectedIndexes] -->


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-bbs/issues/121. Where the text erroneously talks of "ECDSA-SD base proof" or "ECDSA-SD derived proof" these have been changed to "BBS".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-bbs/pull/123.html" title="Last updated on Jan 11, 2024, 10:15 PM UTC (e973af7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/123/ed835c7...Wind4Greg:e973af7.html" title="Last updated on Jan 11, 2024, 10:15 PM UTC (e973af7)">Diff</a>