### PR TITLE
Informative change to fix incorrect count of number of elements.

### DIFF
--- a/index.html
+++ b/index.html
@@ -887,8 +887,8 @@ starting with "`u`" and ending with the base64url-no-pad-encoded value of
 The following algorithm parses the components of the derived proof value.
 The required input is a derived proof value (<var>proofValue</var>). A
 A single <em>derived proof value</em> value object is produced as output, which
-contains a set of four elements, using the names "bbsProof", "labelMap",
-"mandatoryIndexes", and "selectiveIndexes".
+contains a set of four elements, using the names "`bbsProof`", "`labelMap`",
+"`mandatoryIndexes`", and "`selectiveIndexes`".
           </p>
 
           <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -570,7 +570,7 @@ Initialize a byte array, `proofValue`, that starts with the BBS base proof
 header bytes `0xd9`, `0x5d`, and `0x02`.
             </li>
             <li>
-Initialize `components` to an array with five elements containing the values of:
+Initialize `components` to an array with three elements containing the values of:
 `bbsSignature`, `hmacKey`, and `mandatoryPointers`.
             </li>
             <li>
@@ -887,7 +887,7 @@ starting with "`u`" and ending with the base64url-no-pad-encoded value of
 The following algorithm parses the components of the derived proof value.
 The required input is a derived proof value (<var>proofValue</var>). A
 A single <em>derived proof value</em> value object is produced as output, which
-contains a set of five elements, using the names "bbsProof", "labelMap",
+contains a set of four elements, using the names "bbsProof", "labelMap",
 "mandatoryIndexes", and "selectiveIndexes".
           </p>
 
@@ -918,7 +918,7 @@ algorithm in Section <a href="#decompresslabelmap"></a>, passing the existing
 second element of `components` as `compressedLabelMap`.
             </li>
             <li>
-Return <em>derived proof value</em> as an object with properties set to the five
+Return <em>derived proof value</em> as an object with properties set to the four
 elements, using the names "`bbsProof`", "`labelMap`", "`mandatoryIndexes`", and
 "`selectiveIndexes`" respectively.
             </li>


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-bbs/issues/120 regarding the number of elements involved with proof and verification processing. The names of the elements involved are correct the *informative* count of the number of those elements was not and is fixed by this PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-bbs/pull/124.html" title="Last updated on Jan 19, 2024, 5:14 PM UTC (80c82a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/124/ed835c7...Wind4Greg:80c82a4.html" title="Last updated on Jan 19, 2024, 5:14 PM UTC (80c82a4)">Diff</a>