### PR TITLE
Add informative note about code reuse

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,7 +549,7 @@ Return <var>labelMapFactoryFunction</var>.
           <p class="note informative">
 It should be noted that step 1.2 in the above algorithm is identical to step 1.2
 in <a href="https://www.w3.org/TR/vc-di-ecdsa/#createhmacidlabelmapfunction">
-Section 3.3.4 createHmacIdLabelMapFunction</a> of [[DI-ECDSA]]
+Section 3.3.4 `createHmacIdLabelMapFunction`</a> of [[DI-ECDSA]]
 so developers might be able to reuse the code or call the function if implementing
 both.
           </p>

--- a/index.html
+++ b/index.html
@@ -549,7 +549,7 @@ Return <var>labelMapFactoryFunction</var>.
           <p class="note informative">
 It should be noted that step 1.2 in the above algorithm is identical to step 1.2
 in <a href="https://www.w3.org/TR/vc-di-ecdsa/#createhmacidlabelmapfunction">
-Section 3.3.4 `createHmacIdLabelMapFunction`</a> of [[DI-ECDSA]]
+Section 3.3.4 `createHmacIdLabelMapFunction`</a> of [[DI-ECDSA]],
 so developers might be able to reuse the code or call the function if implementing
 both.
           </p>

--- a/index.html
+++ b/index.html
@@ -546,6 +546,13 @@ Return <var>labelMapFactoryFunction</var>.
             </li>
           </ol>
 
+          <p class="note informative">
+It should be noted that step 1.2 in the above algorithm is identical to step 1.2
+in <a href="https://www.w3.org/TR/vc-di-ecdsa/#createhmacidlabelmapfunction">
+Section 3.3.4 createHmacIdLabelMapFunction</a> of [[DI-ECDSA]]
+so developers may be able to reuse the code or call the function if implementing
+both.
+          </p>
         </section>
 
 

--- a/index.html
+++ b/index.html
@@ -550,7 +550,7 @@ Return <var>labelMapFactoryFunction</var>.
 It should be noted that step 1.2 in the above algorithm is identical to step 1.2
 in <a href="https://www.w3.org/TR/vc-di-ecdsa/#createhmacidlabelmapfunction">
 Section 3.3.4 createHmacIdLabelMapFunction</a> of [[DI-ECDSA]]
-so developers may be able to reuse the code or call the function if implementing
+so developers might be able to reuse the code or call the function if implementing
 both.
           </p>
         </section>


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-bbs/issues/119  "Add note that implementers can reuse createHmacIdLabelMapFunction in createShuffledIdLabelMapFunction". 

It does this by adding and informative note ;-)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-bbs/pull/130.html" title="Last updated on Jan 19, 2024, 5:08 PM UTC (3b7dd70)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/130/ed835c7...Wind4Greg:3b7dd70.html" title="Last updated on Jan 19, 2024, 5:08 PM UTC (3b7dd70)">Diff</a>