### PR TITLE
Enhance base proof with bbsHeader and PK

### DIFF
--- a/index.html
+++ b/index.html
@@ -640,7 +640,7 @@ produced as output, which contains the "bbsProof", "labelMap",
 
           <ol class="algorithm">
             <li>
-Initialize `bbsSignature`, `hmacKey`,  and
+Initialize `bbsSignature`, `bbsHeader`, `publicKey`, `hmacKey`,  and
 `mandatoryPointers` to the values of the associated properties in the object
 returned when calling the algorithm in Section
 <a href="#parsebaseproofvalue"></a>, passing the `proofValue` from `proof`.
@@ -716,37 +716,11 @@ array (e.g., `nonMandatoryIndexes.indexOf(key)`), and add this value to the
 Initialize `bbsMessages` to an array of byte arrays obtained from the
 UTF-8 encoding of the the values in the `nonMandatory` array.
             </li>
-            <li>
-Recompute the `bbsHeader` using the following steps:
-
-              <ol class="algorithm">
-                <li>
-Initialize `proofHash` to the result of calling the RDF Dataset Canonicalization
-algorithm [[RDF-CANON]] on `proof` with the `proofValue` removed and then
-cryptographically
-hashing the result using the same hash that is used by the signature algorithm,
-i.e., SHAKE-256. Note: This step can be performed in parallel;
-it only needs to be completed before this algorithm terminates, as the result is
-part of the return value.
-                </li>
-                <li>
-Initialize `mandatoryHash` to the result of calling the algorithm in
-<a href="https://www.w3.org/TR/vc-di-ecdsa/#hashmandatorynquads">Section 3.3.17
-hashMandatoryNQuads</a> of the [[DI-ECDSA]] specification, passing the values
-from the map
-<var>groups.mandatory.matching</var> and utilizing the SHAKE-256 algorithm.
-                </li>
-                <li>
-Set  `bbsHeader` to the concatenation of `proofHash` and `mandatoryHash` in that
-order.
-                </li>
-              </ol>
-            </li>
 
             <li>
 Set `bbsProof` to the value computed by the `ProofGen` procedure from
 [[CFRG-BBS-SIGNATURE]], i.e. `ProofGen(PK, signature, header, ph, messages, disclosed_indexes)`,
-where `PK` is the original issuers public key, `signature` is the
+where `PK` is the original issuers public key `publicKey`, `signature` is the
 `bbsSignature`, `header` is the `bbsHeader`, `ph` is an empty byte array,
 `messages` is `bbsMessages`, and `disclosed_indexes` is `selectiveIndexes`.
             </li>

--- a/index.html
+++ b/index.html
@@ -1248,9 +1248,10 @@ for the `messages`
             </li>
             <li>
 Initialize `proofValue to the result of calling the algorithm in Section
-<a href="#serializebaseproofvalue"></a>, passing `bbsSignature`,
-`hmacKey`, and `mandatoryPointers` as parameters
-to the algorithm.
+<a href="#serializebaseproofvalue"></a>, passing `bbsSignature`, `bbsHeader`,
+`publicKey`, `hmacKey`, and `mandatoryPointers` as parameters
+to the algorithm. Where `publicKey` is a byte array of the public key encoded
+according to [[CFRG-BBS-SIGNATURE]].
             </li>
             <li>
 Return `proofValue` as <em>digital proof</em>.

--- a/index.html
+++ b/index.html
@@ -571,7 +571,7 @@ header bytes `0xd9`, `0x5d`, and `0x02`.
             </li>
             <li>
 Initialize `components` to an array with five elements containing the values of:
-`bbsSignature`, `hmacKey`, and `mandatoryPointers`.
+`bbsSignature`, `bbsHeader`, `publicKey`, `hmacKey`, and `mandatoryPointers`.
             </li>
             <li>
 CBOR-encode `components` and append it to `proofValue`.
@@ -594,8 +594,8 @@ Return `baseProof` as <em>base proof</em>.
 The following algorithm parses the components of a `bbs-2023` selective
 disclosure base proof value. The required input is a proof value
 (<var>proofValue</var>). A single object, <em>parsed base proof</em>, containing
-three elements, using the names "bbsSignature", "hmacKey",
-and "mandatoryPointers", is produced  as output.
+three elements, using the names "bbsSignature", "bbsHeader", "publicKey",
+"hmacKey", and "mandatoryPointers", is produced  as output.
           </p>
 
           <ol class="algorithm">
@@ -614,11 +614,11 @@ bytes `0xd9`, `0x5d`, and `0x02`, and throw an error if it does not.
             <li>
 Initialize `components` to an array that is the result of CBOR-decoding the
 bytes that follow the three-byte ECDSA-SD base proof header. Ensure the result
-is an array of three elements.
+is an array of draft-irtf-cfrg-pairing-friendly-curves-11 elements.
             </li>
             <li>
 Return an object with properties set to the three elements, using the names
-"bbsSignature", "hmacKey", and "mandatoryPointers",
+"bbsSignature", "bbsHeader", "publicKey", "hmacKey", and "mandatoryPointers",
 respectively.
             </li>
           </ol>


### PR DESCRIPTION
This PR addresses issues https://github.com/w3c/vc-di-bbs/issues/125 and https://github.com/w3c/vc-di-bbs/issues/126.

It does this by including the computed value of `bbsHeader` and the value of  `PK` (public key) in the "base proof". The inclusion of `bbsHeader` value allows the holder to forgo a re-computation of the various values and their hashes. The inclusion of the public key allows the holder to forgo possible networking requests for the public key and possible tracking associated with it.