### PR TITLE
Remove reference to RDF Normalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,13 +80,6 @@
         alternateFormats: [ {uri: "diff-20111214.html", label: "diff to previous version"} ],
         */
         localBiblio:  {
-          "RDF-DATASET-NORMALIZATION": {
-            title:    "RDF Dataset Normalization 1.0",
-            href:     "http://json-ld.github.io/normalization/spec/",
-            authors:  ["David Longley", "Manu Sporny"],
-            status:   "CGDRAFT",
-            publisher:  "JSON-LD Community Group"
-          },
           "RDF-CONCEPTS": {
             title:    "RDF 1.1 Concepts and Abstract Syntax",
             href:     "https://www.w3.org/TR/rdf11-concepts/",
@@ -284,8 +277,8 @@ credential received from the holder.
       <p>
 Applying the BBS signature scheme to verifiable credentials involves the
 processing specified in this document.
-In general the suite uses the RDF Dataset Normalization Algorithm
-[[RDF-DATASET-NORMALIZATION]] to transform an input document into its canonical
+In general the suite uses the RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to transform an input document into its canonical
 form. An issuer then uses selective disclosure primitives to separate the
 canonical form into mandatory and non-mandatory statements. These are processed
 separately with other information to serve as the inputs to the BBS `Sign`
@@ -296,7 +289,7 @@ to ascertain validity.
       </p>
       <p>
 Similarly, on receipt of a BBS signed credential, a holder uses the RDF Dataset
-Normalization Algorithm [[RDF-DATASET-NORMALIZATION]] to transform an input
+Canonicalization Algorithm [[RDF-CANON]] to transform an input
 document into its canonical form, and then applies selective disclosure
 primitives to separate the canonical form into mandatory and selectively
 disclosed statements, which are appropriately processed and serve as inputs to


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-bbs/issues/132. It updates the outdated reference and terminology in the introduction. It also removes the outdated reference from the local bibliography.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-bbs/pull/133.html" title="Last updated on Jan 17, 2024, 4:58 PM UTC (c02db3a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/133/ed835c7...Wind4Greg:c02db3a.html" title="Last updated on Jan 17, 2024, 4:58 PM UTC (c02db3a)">Diff</a>