### PR TITLE
Two different references to the same document..

### DIFF
--- a/index.html
+++ b/index.html
@@ -1694,7 +1694,7 @@ structural artifacts used to express JSON data that might leak information
 (nesting, map, or array position, etc.) by using JSON-LD processing to transform
 inputs into RDF. RDF can then be expressed as a canonical, flat format of simple
 subject, property, value statements (referred to as claims in the Verifiable
-Credentials Data Model [[VC-DATA-MODEL-2]]). In the following, we examine RDF
+Credentials Data Model [[VC-DATA-MODEL-2.0]]). In the following, we examine RDF
 canonicalization, a general scheme for mapping a verifiable credential in
 JSON-LD format into a set of <em>statements</em> (BBS <em>messages</em>), for
 selective disclosure. We show that after this process is performed, there


### PR DESCRIPTION
The text uses two different references to the VCDM `[[VC-DATA-MODEL-2]]` and `[[VC-DATA-MODEL-2.0]]`. As a result, there is a duplication of the VCDM reference in the references' list.

This PR keeps the second format.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/pull/135.html" title="Last updated on Jan 19, 2024, 2:18 PM UTC (92ba113)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/135/ed835c7...92ba113.html" title="Last updated on Jan 19, 2024, 2:18 PM UTC (92ba113)">Diff</a>