### PR TITLE
Update Proof Configuration Procedure to Pass Through Proof options

### DIFF
--- a/index.html
+++ b/index.html
@@ -1140,55 +1140,38 @@ that is used as input to the
 
           <p>
 The required inputs to this algorithm are <em>proof options</em>
-(<var>options</var>). The <em>proof options</em> MUST contain a type identifier
+(|options|). The <em>proof options</em> MUST contain a type identifier
 for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (<var>type</var>) and MUST contain a cryptosuite
-identifier (<var>cryptosuite</var>). A <em>proof configuration</em>
+cryptographic suite</a> (|type|) and MUST contain a cryptosuite
+identifier (|cryptosuite|). A <em>proof configuration</em>
 object is produced as output.
           </p>
 
           <ol class="algorithm">
             <li>
-Let <var>proofConfig</var> be an empty object.
+Let |proofConfig| be a clone of the |options| object.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>type</var> to
-<var>options</var>.<var>type</var>.
-            </li>
-            <li>
-If <var>options</var>.<var>cryptosuite</var> is set, set
-<var>proofConfig</var>.<var>cryptosuite</var> to its value.
-            </li>
-            <li>
-If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
-<var>proofConfig</var>.<var>cryptosuite</var> is not set to `bbs-2023`, an
+If |proofConfig|.|type| is not set to `DataIntegirtyProof` and/or
+|proofConfig|.|cryptosuite| is not set to `bbs-2023`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>created</var> to
-<var>options</var>.<var>created</var>. If the value is not a valid
-[[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
+If |proofConfig|.|created| is set and if the value is not a
+valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
+raised.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>verificationMethod</var> to
-<var>options</var>.<var>verificationMethod</var>.
+Set |proofConfig|.<var>@context</var> to
+|unsecuredDocument|.<var>@context</var>.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>proofPurpose</var> to
-<var>options</var>.<var>proofPurpose</var>.
+Let |canonicalProofConfig| be the result of applying the Universal RDF Dataset
+Canonicalization Algorithm [[RDF-CANON]] to the |proofConfig|.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>@context</var> to
-<var>unsecuredDocument</var>.<var>@context</var>.
-            </li>
-            <li>
-Let <var>canonicalProofConfig</var> be the result of applying the
-Universal RDF Dataset Canonicalization Algorithm
-[[RDF-CANON]] to the <var>proofConfig</var>.
-            </li>
-            <li>
-Return <var>canonicalProofConfig</var>.
+Return |canonicalProofConfig|.
             </li>
           </ol>
 

--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
         },
         lint: {"no-unused-dfns": false},
         postProcess: [restrictRefs],
-        xref: [ "i18n-glossary" ]
+        xref: ["INFRA", "VC-DATA-MODEL-2.0", "VC-DATA-INTEGRITY", "i18n-glossary"]
       };
     </script>
         <style>
@@ -302,8 +302,11 @@ the BBS `verifyProof` function to validate the credential.
 
       <section id="terminology">
         <h3>Terminology</h3>
-
-        <div data-include="https://w3c.github.io/vc-data-integrity/terms.html"></div>
+        <p>
+Terminology used throughout this document is defined in the
+<a data-cite="VC-DATA-INTEGRITY#terminology">Terminology</a> section of the
+[[[VC-DATA-INTEGRITY]]] specification.
+        </p>
 
       </section>
 


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-bbs/issues/139 to bring this specification in line with the [VC-DI-ECDSA](https://w3c.github.io/vc-di-ecdsa/#base-proof-configuration-ecdsa-sd-2023) specification on the pass through of additional options during proof configuration.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-bbs/pull/141.html" title="Last updated on Mar 3, 2024, 9:40 PM UTC (f3dc5cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/141/cfef8e3...Wind4Greg:f3dc5cf.html" title="Last updated on Mar 3, 2024, 9:40 PM UTC (f3dc5cf)">Diff</a>