### PR TITLE
Specify HMAC key size

### DIFF
--- a/index.html
+++ b/index.html
@@ -1042,9 +1042,10 @@ MUST use UTF-8 encoding.
           </p>
           <ol class="algorithm">
             <li>
-Initialize `hmac` to an HMAC API using a locally generated and exportable HMAC
+Initialize |hmac| to an HMAC API using a locally generated and exportable HMAC
 key. The HMAC uses the same hash algorithm used in the signature algorithm,
-i.e., SHA-256.
+i.e., SHA-256. Per the recommendations of [[RFC2104]], the HMAC key MUST be the
+same length as the digest size; for SHA-256, this is 256 bits or 32 bytes.
             </li>
             <li>
 Initialize `labelMapFactoryFunction` to the result of calling the

--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
         },
         lint: {"no-unused-dfns": false},
         postProcess: [restrictRefs],
-        xref: [ "i18n-glossary" ]
+        xref: ["INFRA", "VC-DATA-MODEL-2.0", "VC-DATA-INTEGRITY", "i18n-glossary"]
       };
     </script>
         <style>
@@ -302,8 +302,11 @@ the BBS `verifyProof` function to validate the credential.
 
       <section id="terminology">
         <h3>Terminology</h3>
-
-        <div data-include="https://w3c.github.io/vc-data-integrity/terms.html"></div>
+        <p>
+Terminology used throughout this document is defined in the
+<a data-cite="VC-DATA-INTEGRITY#terminology">Terminology</a> section of the
+[[[VC-DATA-INTEGRITY]]] specification.
+        </p>
 
       </section>
 


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-bbs/issues/139 which references a similar issue that arose in ECDSA-SD https://github.com/w3c/vc-di-ecdsa/issues/58. This PR gives specific value for the HMAC key length and provides a reference that justifies the chosen value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-bbs/pull/143.html" title="Last updated on Mar 3, 2024, 9:46 PM UTC (0154d53)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/143/cfef8e3...Wind4Greg:0154d53.html" title="Last updated on Mar 3, 2024, 9:46 PM UTC (0154d53)">Diff</a>