### PR TITLE
Update algorithms to align with new cryptosuite interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1435,27 +1435,49 @@ Return `revealDocument` as the <em>selectively revealed document</em>.
 
         </section>
 
-
         <section>
           <h4>Verify Derived Proof (bbs-2023)</h4>
 
           <p>
-The following algorithm attempts verification of a `bbs-2023` derived
-proof. This algorithm is called by a verifier of an BBS-protected
-<a>verifiable credential</a>. The inputs include a JSON-LD document
-(<var>document</var>), a BBS disclosure proof (<var>proof</var>), and any
-custom JSON-LD API options (such as a document loader). A single boolean
-<em>verification result</em> value is produced as output.
+The following algorithm specifies how to verify a [=data integrity proof=] given
+an <a>secured data document</a>. Required inputs are an
+<a>secured data document</a> ([=map=] |securedDocument|). This algorithm returns
+a <dfn>verification result</dfn>, which is a [=struct=] whose
+[=struct/items=] are:
+          </p>
+
+          <dl>
+            <dt><dfn data-dfn-for="verification result">verified</dfn></dt>
+            <dd>`true` or `false`</dd>
+            <dt><dfn data-dfn-for="verification result">verifiedDocument</dfn></dt>
+            <dd>
+<a data-cite="INFRA#nulls">Null</a>, if [=verification result/verified=] is
+`false`; otherwise, an [=unsecured data document=]
+            </dd>
+          </dl>
+
+          <p>
+To verify a derived proof, perform the following steps:
           </p>
 
           <ol class="algorithm">
-            <!-- [bbsProof, labelMapCompressed, mandatoryIndexes, adjSelectedIndexes] -->
+            <li>
+Let |unsecuredDocument| be a copy of |securedDocument| with
+the `proof` value removed.
+            </li>
+            <li>
+Let |proofConfig| be a copy of |securedDocument|.|proof| with `proofValue`
+removed.
+            </li>
+            <li>
+Let |proof| be the value of |securedDocument|.|proof|.
+            </li>
             <li>
 Initialize `bbsProof`, `proofHash`, `mandatoryHash`, `selectedIndexes`,
 `presentationHeader`, `pseudonym`, and `nonMandatory` to the values associated with their
 property names in the object returned when calling the algorithm in Section
-<a href="#createverifydata"></a>, passing the `document`, `proof`, and any
-custom JSON-LD API options (such as a document loader).
+<a href="#createverifydata"></a>, passing the |unsecuredDocument|, |proof|, and
+any custom JSON-LD API options (such as a document loader).
             </li>
             <li>
 Initialize `bbsHeader` to the concatenation of `proofHash` and `mandatoryHash`
@@ -1463,7 +1485,7 @@ in that order. Initialize `disclosedMessages` to an array of byte arrays
 obtained from the UTF-8 encoding of the elements of the `nonMandatory` array.
             </li>
             <li>
-Initialize `verificationResult` to the result of applying the verification
+Initialize |verified| to the result of applying the verification
 algorithm below, depending on whether the |pseudonym| value is empty.
             <ol class="algorithm">
               <li>
@@ -1495,14 +1517,23 @@ This applies to the "pseudonym with issuer known pid" and "pseudonym with
 hidden pid" cases.
               </li>
             </ol>
-
+          </li>
+          <li>
+Return a [=verification result=] with [=struct/items=]:
+              <dl data-link-for="verification result">
+                <dt>[=verified=]</dt>
+                <dd>|verified|</dd>
+                <dt>[=verifiedDocument=]</dt>
+                <dd>
+|unsecuredDocument| if |verified| is `true`, otherwise <a
+data-cite="INFRA#nulls">Null</a>
+                </dd>
+              </dl>
             </li>
           </ol>
 
         </section>
-
       </section>
-
     </section>
     <section class="informative">
       <h2>Optional Features</h2>

--- a/index.html
+++ b/index.html
@@ -488,6 +488,45 @@ by default, and abort processing upon detection.
       </p>
 
       <section>
+        <h3>Instantiate Cryptosuite</h3>
+
+        <p>
+This algorithm is used to configure a cryptographic suite to be used by the
+<a data-cite="VC-DATA-INTEGRITY#add-proof">Add Proof</a> and
+<a href="VC-DATA-INTEGRITY#verify-proof">Verify Proof</a>
+functions in [[[VC-DATA-INTEGRITY]]]. The algorithm takes an options object
+([=map=] |options|) as input and returns a [=data integrity cryptographic suite
+instance|cryptosuite instance=] ([=struct=] |cryptosuite|).
+        </p>
+
+        <ol class="algorithm">
+          <li>
+Initialize |cryptosuite| to an empty [=struct=].
+          </li>
+          <li>
+If |options|.|type| does not equal `DataIntegrityProof`, return |cryptosuite|.
+          </li>
+          <li>
+If |options|.|cryptosuite| is `bbs-2023` then:
+            <ol class="algorithm">
+              <li>
+Set |cryptosuite|.|createProof| to the algorithm in Section
+[[[#create-base-proof-bbs-2023]]].
+              </li>
+              <li>
+Set |cryptosuite|.|verifyProof| to the algorithm in Section
+[[[#verify-derived-proof-bbs-2023]]].
+              </li>
+            </ol>
+          </li>
+          <li>
+Return |cryptosuite|.
+          </li>
+        </ol>
+
+      </section>
+
+      <section>
         <h3>Selective Disclosure Functions</h3>
 
         <section>

--- a/index.html
+++ b/index.html
@@ -1111,8 +1111,8 @@ Section [[[#base-proof-configuration-bbs-2023]]] with
 |options| passed as a parameter.
             </li>
             <li>
-Let |transformedData| be the result of running the algorithm in Section <a
-href="#base-proof-transformation-bbs-2023"></a> with |unsecuredDocument|,
+Let |transformedData| be the result of running the algorithm in Section
+[[[#base-proof-transformation-bbs-2023]]] with |unsecuredDocument|,
 |proofConfig|, and |options| passed as parameters.
             </li>
             <li>
@@ -1440,7 +1440,7 @@ Return `revealDocument` as the <em>selectively revealed document</em>.
 
           <p>
 The following algorithm specifies how to verify a [=data integrity proof=] given
-an <a>secured data document</a>. Required inputs are an
+an <a>secured data document</a>. Required inputs are a
 <a>secured data document</a> ([=map=] |securedDocument|). This algorithm returns
 a <dfn>verification result</dfn>, which is a [=struct=] whose
 [=struct/items=] are:

--- a/index.html
+++ b/index.html
@@ -1474,10 +1474,10 @@ Let |proof| be the value of |securedDocument|.|proof|.
             </li>
             <li>
 Initialize `bbsProof`, `proofHash`, `mandatoryHash`, `selectedIndexes`,
-`presentationHeader`, `pseudonym`, and `nonMandatory` to the values associated with their
-property names in the object returned when calling the algorithm in Section
-<a href="#createverifydata"></a>, passing the |unsecuredDocument|, |proof|, and
-any custom JSON-LD API options (such as a document loader).
+`presentationHeader`, `pseudonym`, and `nonMandatory` to the values associated
+with their property names in the object returned when calling the algorithm in
+Section <a href="#createverifydata"></a>, passing the |unsecuredDocument|,
+|proof|, and any custom JSON-LD API options (such as a document loader).
             </li>
             <li>
 Initialize `bbsHeader` to the concatenation of `proofHash` and `mandatoryHash`
@@ -1489,32 +1489,25 @@ Initialize |verified| to the result of applying the verification
 algorithm below, depending on whether the |pseudonym| value is empty.
             <ol class="algorithm">
               <li>
-If the |pseudonym| value is empty,
-initialize `verificationResult` to the result of applying the verification
-algorithm
-`ProofVerify(PK, proof, header, ph, disclosed_messages, disclosed_indexes)` of
-[[CFRG-BBS-SIGNATURE]]
-with `PK` set as the public key of the original issuer, `proof` set as `bbsProof`,
-`header` set as `bbsHeader`, `disclosed_messages` set as `disclosedMessages`,
-`ph` set as `presentationHeader`, and `disclosed_indexes` set as
-`selectiveIndexes`. Return `verificationResult` as <em>verification result</em>.
-This applies to the regular BBS proof case as well as "anonymous holder binding"
+If the |pseudonym| value is empty, initialize |verified| to the result of
+applying the verification algorithm `ProofVerify(PK, proof, header, ph,
+disclosed_messages, disclosed_indexes)` of [[CFRG-BBS-SIGNATURE]] with `PK` set
+as the public key of the original issuer, `proof` set as `bbsProof`, `header`
+set as `bbsHeader`, `disclosed_messages` set as `disclosedMessages`, `ph` set as
+`presentationHeader`, and `disclosed_indexes` set as `selectiveIndexes`. This
+applies to the regular BBS proof case as well as "anonymous holder binding"
 case.
               </li>
               <li>
-If the |pseudonym| value is not empty,
-initialize `verificationResult` to the result of applying the verification
-algorithm
-`PseudonymProofVerify(PK, proof, header, ph, disclosed_messages, disclosed_indexes, pseudonym)`
-of
-[[CFRG-Pseudonym-BBS-Signature]],
-with `PK` set as the public key of the original issuer, `proof` set as `bbsProof`,
-`header` set as `bbsHeader`, `disclosed_messages` set as `disclosedMessages`,
-`ph` set as `presentationHeader`, `disclosed_indexes` set as
-`selectiveIndexes`, and `pseudonym`. Return `verificationResult` as
-<em>verification result</em>.
-This applies to the "pseudonym with issuer known pid" and "pseudonym with
-hidden pid" cases.
+If the |pseudonym| value is not empty, initialize |verified| to the result of
+applying the verification algorithm `PseudonymProofVerify(PK, proof, header, ph,
+disclosed_messages, disclosed_indexes, pseudonym)` of
+[[CFRG-Pseudonym-BBS-Signature]], with `PK` set as the public key of the
+original issuer, `proof` set as `bbsProof`, `header` set as `bbsHeader`,
+`disclosed_messages` set as `disclosedMessages`, `ph` set as
+`presentationHeader`, `disclosed_indexes` set as `selectiveIndexes`, and
+`pseudonym`. This applies to the "pseudonym with issuer known pid" and
+"pseudonym with hidden pid" cases.
               </li>
             </ol>
           </li>
@@ -1525,8 +1518,8 @@ Return a [=verification result=] with [=struct/items=]:
                 <dd>|verified|</dd>
                 <dt>[=verifiedDocument=]</dt>
                 <dd>
-|unsecuredDocument| if |verified| is `true`, otherwise <a
-data-cite="INFRA#nulls">Null</a>
+|unsecuredDocument| if |verified| is `true`, otherwise
+<a data-cite="INFRA#nulls">Null</a>
                 </dd>
               </dl>
             </li>

--- a/index.html
+++ b/index.html
@@ -1091,24 +1091,49 @@ in this section also include the verification of such a data integrity proof.
         </p>
 
         <section>
-          <h4>Add Base Proof (bbs-2023)</h4>
+          <h4>Create Base Proof (bbs-2023)</h4>
 
           <p>
-To generate a base proof, the algorithm in
-<a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
-Section 4.1: Add Proof</a> of the Data Integrity
-[[VC-DATA-INTEGRITY]] specification MUST be executed.
-For that algorithm, the cryptographic suite specific
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
-transformation algorithm</a> is defined in Section
-<a href="#base-proof-transformation-bbs-2023"></a>, the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
-hashing algorithm</a> is defined in Section <a href="#base-proof-hashing-bbs-2023"></a>,
-and the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
-proof serialization algorithm</a> is defined in Section
-<a href="#base-proof-serialization-bbs-2023"></a>.
+The following algorithm specifies how to create a [=data integrity proof=] given
+an <a>unsecured data document</a>. Required inputs are an
+<a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of proof
+options ([=map=] |options|). A [=data integrity proof=] ([=map=]), or an error,
+is produced as output.
           </p>
+
+          <ol class="algorithm">
+            <li>
+Let |proof| be a clone of the proof options, |options|.
+            </li>
+            <li>
+Let |proofConfig| be the result of running the algorithm in
+Section [[[#base-proof-configuration-bbs-2023]]] with
+|options| passed as a parameter.
+            </li>
+            <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#base-proof-transformation-bbs-2023"></a> with |unsecuredDocument|,
+|proofConfig|, and |options| passed as parameters.
+            </li>
+            <li>
+Let |hashData| be the result of running the algorithm in Section
+[[[#base-proof-hashing-bbs-2023]]] with |transformedData| and |proofConfig|
+passed as a parameters.
+            </li>
+            <li>
+Let |proofBytes| be the result of running the algorithm in Section
+[[[#base-proof-serialization-bbs-2023]]] with |hashData| and
+|options| passed as parameters.
+            </li>
+            <li>
+Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
+base64url-encoded Multibase value</a> of the |proofBytes|.
+            </li>
+            <li>
+Return |proof| as the [=data integrity proof=].
+            </li>
+          </ol>
+
         </section>
 
         <section>


### PR DESCRIPTION
This PR aligns the specification with the new cryptosuite interface introduced by PR w3c/vc-data-integrity#244.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/pull/144.html" title="Last updated on Mar 14, 2024, 7:51 PM UTC (892868f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/144/1917a17...892868f.html" title="Last updated on Mar 14, 2024, 7:51 PM UTC (892868f)">Diff</a>