### PR TITLE
Update auto-publish.yml for CR Drafts

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -17,4 +17,4 @@ jobs:
           W3C_WG_DECISION_URL: https://www.w3.org/2017/vc/WG/Meetings/Minutes/2023-04-12-vcwg#resolution1
           W3C_BUILD_OVERRIDE: |
              shortName: vc-di-bbs
-             specStatus: WD
+             specStatus: CRD


### PR DESCRIPTION
As the title says. 

This PR should be merged (1) ***after*** the publication of the CR on 2024-04-04 and (2) ***before*** any other PR merge.