### PR TITLE
Procedures update for optional features

### DIFF
--- a/index.html
+++ b/index.html
@@ -679,9 +679,10 @@ Return |baseProof| as <em>base proof</em>.
 The following algorithm parses the components of a `bbs-2023` selective
 disclosure base proof value. The required input is a proof value
 (|proofValue|). A single object, <em>parsed base proof</em>, containing
-five  or seven elements, using the names "bbsSignature", "bbsHeader",
+six or seven elements, using the names "bbsSignature", "bbsHeader",
 "publicKey",
-"hmacKey", "mandatoryPointers", and optional feature parameters "pid" and
+"hmacKey", "mandatoryPointers", "featureOption", and possibly optional feature
+parameters "pid" and
 "signer_blind" is produced  as output.
           </p>
 
@@ -696,22 +697,68 @@ indicating that it is a `multibase-base64url-no-pad-encoded` value, and throw
 an error if it does not.
             </li>
             <li>
-Initialize `decodedProofValue` to the result of base64url-no-pad-decoding the
+Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
 substring following the leading `u` in `proofValue`.
             </li>
             <li>
-Ensure that the `decodedProofValue` starts with the BBS base proof header
-bytes `0xd9`, `0x5d`, and `0x02`, and throw an error if it does not.
+Check that the BBS base proof starts with an allowed header value and set the
+|featureOption| variable as follows:
+              <ol class="algorithm">
+                <li>
+If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x02` set
+|featureOption| to `"baseline"`.
+                </li>
+                <li>
+If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x04` set
+|featureOption| to `"anonymous_holder_binding"`.
+                </li>
+                <li>
+If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x06` set
+|featureOption| to `"pseudonym_issuer_pid"`.
+                </li>
+                <li>
+If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x08` set
+|featureOption| to `"pseudonym_hidden_pid"`.
+                </li>
+                <li>
+If the |decodedProofValue| starts with any other three byte sequence throw an
+error.
+                </li>
+              </ol>
+
             </li>
             <li>
 Initialize `components` to an array that is the result of CBOR-decoding the
 bytes that follow the three-byte BBS base proof header.
             </li>
             <li>
-Return an object with properties set to the following elements, using the names
-"bbsSignature", "bbsHeader", "publicKey", "hmacKey", "mandatoryPointers", (and
-optional feature parameters) "pid" and "signer_blind"
-respectively.
+Based on the value of |featureOption| return an object based on |components|
+as follows:
+              <ol class="algorithm">
+                <li>
+If |featureOption| equals `"baseline"` set the property names for the object
+based on |components| to "bbsSignature", "bbsHeader", "publicKey", "hmacKey",
+"mandatoryPointers" in that order and add |featureOption| as a property.
+                </li>
+                <li>
+If |featureOption| equals `"anonymous_holder_binding"` set the property names
+for the object based on |components| to "bbsSignature", "bbsHeader",
+"publicKey", "hmacKey", "mandatoryPointers", "signer_blind" in that order and
+add |featureOption| as a property.
+                </li>
+                <li>
+If |featureOption| equals `"pseudonym_issuer_pid"` set the property names
+for the object based on |components| to "bbsSignature", "bbsHeader",
+"publicKey", "hmacKey", "mandatoryPointers", "pid" in that order and
+add |featureOption| as a property.
+                </li>
+                <li>
+If |featureOption| equals `"pseudonym_hidden_pid"` set the property names
+for the object based on |components| to "bbsSignature", "bbsHeader",
+"publicKey", "hmacKey", "mandatoryPointers", "signer_blind" in that order and
+add |featureOption| as a property.
+                </li>
+              </ol>
             </li>
           </ol>
 

--- a/index.html
+++ b/index.html
@@ -603,7 +603,7 @@ Depending upon the value of the |featureOption| set up the |proofValue| as
 follows.
             </li>
             <li>
-If |proofValue| equals `"baseline"`:
+If |featureOption| equals `"baseline"`:
               <ol class="algorithm">
                 <li>
 Initialize a byte array, |proofValue|, that starts with the BBS base proof
@@ -616,7 +616,7 @@ Initialize |components| to an array with five elements containing the values of:
               </ol>
             </li>
             <li>
-If |proofValue| equals `"anonymous_holder_binding"`:
+If |featureOption| equals `"anonymous_holder_binding"`:
               <ol class="algorithm">
                 <li>
 Initialize a byte array, |proofValue|, that starts with the BBS base proof
@@ -630,7 +630,7 @@ Initialize |components| to an array with five elements containing the values of:
               </ol>
             </li>
             <li>
-If |proofValue| equals `"pseudonym_issuer_pid"`:
+If |featureOption| equals `"pseudonym_issuer_pid"`:
               <ol class="algorithm">
                 <li>
 Initialize a byte array, |proofValue|, that starts with the BBS base proof
@@ -644,7 +644,7 @@ Initialize |components| to an array with five elements containing the values of:
               </ol>
             </li>
             <li>
-If |proofValue| equals `"pseudonym_hidden_pid"`:
+If |featureOption| equals `"pseudonym_hidden_pid"`:
               <ol class="algorithm">
                 <li>
 Initialize a byte array, |proofValue|, that starts with the BBS base proof
@@ -1024,8 +1024,8 @@ The following algorithm serializes a derived proof value. The required inputs
 are a BBS proof (|bbsProof|), a label map (|labelMap|), an
 array of mandatory indexes (|mandatoryIndexes|), an array of
 selective indexes (|selectiveIndexes|), and a BBS presentation header
-(|presentationHeader|).
-Optional input is |pseudonym|.
+(|presentationHeader|), the |featureOption| indicator, and possibly a
+|pseudonym| value depending on the |featureOption| value.
 A single <em>derived proof</em>
 value, serialized as a byte string, is produced as output.
           </p>
@@ -1036,14 +1036,66 @@ Initialize `compressedLabelMap` to the result of calling the algorithm in
 Section <a href="#compresslabelmap"></a>, passing `labelMap` as the parameter.
             </li>
             <li>
-Initialize a byte array, `proofValue`, that starts with the BBS disclosure
-proof header bytes `0xd9`, `0x5d`, and `0x03`.
-            </li>
-            <li>
+ Depending on the value of |featureOption| do the following:
+              <ol class="algorithm">
+                <li>
+If |featureOption| equals `"baseline"`:
+                  <ol class="algorithm">
+                    <li>
+Initialize |proofValue| to start with the
+disclosure proof header bytes `0xd9`, `0x5d`, and `0x03`.
+                    </li>
+                    <li>
+Initialize |components| to an array with elements containing the values of
+|bbsProof|, |compressedLabelMap|, |mandatoryIndexes|, |selectiveIndexes|, and
+|presentationHeader|.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+If |featureOption| equals `"anonymous_holder_binding"`:
+                  <ol class="algorithm">
+                    <li>
+Initialize |proofValue| to start with the
+disclosure proof header bytes `0xd9`, `0x5d`, and `0x05`.
+                    </li>
+                    <li>
+Initialize |components| to an array with elements containing the values of
+|bbsProof|, |compressedLabelMap|, |mandatoryIndexes|, |selectiveIndexes|, and
+|presentationHeader|.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+If |featureOption| equals `"pseudonym_issuer_pid"`:
+                  <ol class="algorithm">
+                    <li>
+Initialize |proofValue| to start with the
+disclosure proof header bytes `0xd9`, `0x5d`, and `0x07`.
+                    </li>
+                    <li>
 Initialize |components| to an array with elements containing the values of
 |bbsProof|, |compressedLabelMap|, |mandatoryIndexes|, |selectiveIndexes|,
-|presentationHeader|, and, if provided,|pseudonym|.
-            </li>
+|presentationHeader|, and |pseudonym|.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+If |featureOption| equals `"pseudonym_hidden_pid"`:
+                  <ol class="algorithm">
+                    <li>
+Initialize |proofValue| to start with the
+disclosure proof header bytes `0xd9`, `0x5d`, and `0x09`.
+                    </li>
+                    <li>
+Initialize |components| to an array with elements containing the values of
+|bbsProof|, |compressedLabelMap|, |mandatoryIndexes|, |selectiveIndexes|,
+|presentationHeader|, and |pseudonym|.
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+
             <li>
 CBOR-encode |components| per [[RFC8949]] where CBOR tagging MUST NOT be used on
 any of the |components|. Append the produced encoded value to |proofValue|.

--- a/index.html
+++ b/index.html
@@ -1558,19 +1558,19 @@ inputs based on the |featureOption|, and any custom JSON-LD API options,
 such as a document loader.
             </li>
             <li>
-Initialize `newProof` to a shallow copy of `proof`.
+Initialize |newProof| to a shallow copy of |proof|.
             </li>
             <li>
-Replace `proofValue` in `newProof` with the result of calling the algorithm
-in Section <a href="#serializederivedproofvalue"></a>, passing `bbsProof`,
-`labelMap`, `mandatoryIndexes`, `selectiveIndexes`, |commitment_with_proof|, and
-|pid|.
+Replace |proofValue| in |newProof| with the result of calling the algorithm
+in Section <a href="#serializederivedproofvalue"></a>, passing |bbsProof|,
+|labelMap|, |mandatoryIndexes|, |selectiveIndexes|, |featureOption|, and any
+required inputs indicated by the |featureOption|.
             </li>
             <li>
-Set the value of the "`proof`" property in `revealDocument` to `newProof`.
+Set the value of the "`proof`" property in |revealDocument| to |newProof|.
             </li>
             <li>
-Return `revealDocument` as the <em>selectively revealed document</em>.
+Return |revealDocument| as the <em>selectively revealed document</em>.
             </li>
           </ol>
 

--- a/index.html
+++ b/index.html
@@ -726,48 +726,47 @@ inputs include a JSON-LD document (|document|), a BBS base proof
 (|proof|), an array of JSON pointers to use to selectively disclose
 statements (|selectivePointers|), an OPTIONAL BBS
 |presentationHeader| (byte array that defaults to an empty byte array if
-not present),
-an OPTIONAL
-|commitment_with_proof| (a byte array), an OPTIONAL |pid| value (a byte array),
+not present), a |featureOption| indicator, additional inputs as required by
+the |featureOption| (see <a href="#add-derived-proof-bbs-2023">Add Derived Proof</a>),
 and any custom JSON-LD API options
 (such as a document loader). A single object, <em>disclosure data</em>, is
-produced as output, which contains the `bbsProof`, `labelMap`,
-`mandatoryIndexes`, `selectiveIndexes`, `presentationHeader`, and
-`revealDocument` fields.
+produced as output, which contains the |bbsProof|, |labelMap|,
+|mandatoryIndexes|, |selectiveIndexes|, |presentationHeader|,
+|revealDocument|, and |pseudonym| (if computed) fields.
           </p>
 
           <ol class="algorithm">
             <li>
-Initialize `bbsSignature`, `bbsHeader`, `publicKey`, `hmacKey`,
-`mandatoryPointers`, and the optional feature parameters `pid` and
-`signer_blind` to the values of the associated properties in the object
+Initialize |bbsSignature|, |bbsHeader|, |publicKey|, |hmacKey|,
+|mandatoryPointers|, and the optional feature parameters |pid| and
+|signer_blind| to the values of the associated properties in the object
 returned when calling the algorithm in Section
 <a href="#parsebaseproofvalue"></a>, passing the `proofValue` from `proof`.
             </li>
             <li>
-Initialize `hmac` to an HMAC API using `hmacKey`. The HMAC uses the same hash
+Initialize |hmac| to an HMAC API using |hmacKey|. The HMAC uses the same hash
 algorithm used in the signature algorithm, i.e., SHA-256.
             </li>
             <li>
-Initialize `labelMapFactoryFunction` to the result of calling the
-`createShuffledIdLabelMapFunction` algorithm passing `hmac` as `HMAC`.
+Initialize |labelMapFactoryFunction| to the result of calling the
+|createShuffledIdLabelMapFunction| algorithm passing |hmac| as |HMAC|.
             </li>
             <li>
-Initialize `combinedPointers` to the concatenation of `mandatoryPointers`
-and `selectivePointers`.
+Initialize |combinedPointers| to the concatenation of |mandatoryPointers|
+and |selectivePointers|.
             </li>
             <li>
-Initialize `groupDefinitions` to a map with the following entries: key of
-the string `"mandatory"` and value of `mandatoryPointers`; key of the string
-`"selective"` and value of `selectivePointers`; and key of the string `"combined"`
-and value of `combinedPointers`.
+Initialize |groupDefinitions| to a map with the following entries: key of
+the string `"mandatory"` and value of |mandatoryPointers|; key of the string
+`"selective"` and value of |selectivePointers|; and key of the string `"combined"`
+and value of |combinedPointers|.
             </li>
             <li>
-Initialize `groups` and `labelMap` to the result of calling the algorithm in
+Initialize |groups| and |labelMap| to the result of calling the algorithm in
 <a href="https://www.w3.org/TR/vc-di-ecdsa/#canonicalizeandgroup">Section 3.3.16
-canonicalizeAndGroup</a> of the [[DI-ECDSA]] specification, passing `document`
-`labelMapFactoryFunction`,
-`groupDefinitions`, and any custom JSON-LD
+canonicalizeAndGroup</a> of the [[DI-ECDSA]] specification, passing |document|
+|labelMapFactoryFunction|,
+|groupDefinitions|, and any custom JSON-LD
 API options. Note: This step transforms the document into an array of canonical
 N-Quads whose order has been shuffled based on 'hmac' applied blank node
 identifiers, and groups
@@ -780,15 +779,15 @@ statement list, i.e., find the position at which a mandatory statement occurs
 in the list of combined statements. One method for doing this is given below.
               <ol class="algorithm">
                 <li>
-Initialize `mandatoryIndexes` to an empty array. Set `mandatoryMatch` to
-`groups.mandatory.matching` map; set `combinedMatch` to
-`groups.combined.matching`; and set `combinedIndexes` to the ordered array of
-just the keys of the `combinedMatch` map.
+Initialize |mandatoryIndexes| to an empty array. Set |mandatoryMatch| to
+|groups.mandatory.matching| map; set |combinedMatch| to
+|groups.combined.matching|; and set |combinedIndexes| to the ordered array of
+just the keys of the |combinedMatch| map.
                 </li>
                 <li>
-For each key in the `mandatoryMatch` map, find its index in the `combinedIndexes`
+For each key in the |mandatoryMatch| map, find its index in the |combinedIndexes|
 array (e.g., `combinedIndexes.indexOf(key)`), and add this value to the
-`mandatoryIndexes` array.
+|mandatoryIndexes| array.
                 </li>
               </ol>
             </li>
@@ -798,28 +797,29 @@ statement list, i.e., find the position at which a selected statement occurs in
 the list of non-mandatory statements. One method for doing this is given below.
               <ol class="algorithm">
                 <li>
-Initialize `selectiveIndexes` to an empty array. Set `selectiveMatch` to the
-`groups.selective.matching` map; set `mandatoryNonMatch` to the map
-`groups.mandatory.nonMatching`; and `nonMandatoryIndexes` to to the ordered array of
-just the keys of the `mandatoryNonMatch` map.
+Initialize |selectiveIndexes| to an empty array. Set |selectiveMatch| to the
+|groups.selective.matching| map; set |mandatoryNonMatch| to the map
+|groups.mandatory.nonMatching|; and |nonMandatoryIndexes| to to the ordered
+array of just the keys of the |mandatoryNonMatch| map.
                 </li>
                 <li>
-For each key in the `selectiveMatch` map, find its index in the `nonMandatoryIndexes`
-array (e.g., `nonMandatoryIndexes.indexOf(key)`), and add this value to the
-`selectiveIndexes` array.
+For each key in the |selectiveMatch| map, find its index in the
+|nonMandatoryIndexes| array (e.g., `nonMandatoryIndexes.indexOf(key)`), and add
+this value to the |selectiveIndexes| array.
                 </li>
               </ol>
             </li>
             <li>
-Initialize `bbsMessages` to an array of byte arrays containing the values in the
-`nonMandatory` array of strings encoded using the UTF-8 <a>character encoding</a>.
+Initialize |bbsMessages| to an array of byte arrays containing the values in the
+|nonMandatory| array of strings encoded using the UTF-8
+<a>character encoding</a>.
             </li>
             <li>
-Set `bbsProof` to the value computed by the appropriate procedure given below
-based on the values of the |commitment_with_proof| and |pid| options.
+Set |bbsProof| to the value computed by the appropriate procedure given below
+based on the value of the |featureOption| parameter.
               <ol class="algorithm">
                 <li>
-If both |commitment_with_proof| and |pid| options are empty,
+If |featureOption| equals `"baseline"`,
 set `bbsProof` to the value computed by the `ProofGen` procedure from
 [[CFRG-BBS-SIGNATURE]], i.e.,
 `ProofGen(PK, signature, header, ph, messages, disclosed_indexes)`,
@@ -828,34 +828,57 @@ where `PK` is the original issuers public key, `signature` is the
 `messages` is `bbsMessages`, and `disclosed_indexes` is `selectiveIndexes`.
                 </li>
                 <li>
-If |commitment_with_proof| is not empty and |pid| is empty,
+If |featureOption| equals `"anonymous_holder_binding"`,
 set `bbsProof` to the value computed by the `ProofGen` procedure from
-[[CFRG-Blind-BBS-Signature]], where `PK` is the original issuers public key,
-`signature` is the
-`bbsSignature`, `header` is the `bbsHeader`, `ph` is the  `presentationHeader`
-`messages` is `bbsMessages`, `disclosed_indexes` is `selectiveIndexes`,
+[[CFRG-Blind-BBS-Signature]], where |PK| is the original issuers public key,
+|signature| is the
+|bbsSignature|, |header| is the |bbsHeader|, |ph| is the  |presentationHeader|,
+|messages| is |bbsMessages|, |disclosed_indexes| is |selectiveIndexes|,
 `commitment_with_proof`, and `signer_blind`. The holder will also furnish its
-"secret value" that was used to compute the `commitment_with_proof`. This is the
-"anonymous holder binding" option.
+|holder_secret|, and |proverBlind| that was used to compute the
+|commitment_with_proof|. This is the
+<a href="#anonymous-holder-binding">Anonymous Holder Binding</a> feature option.
+In addition to the |bbsProof| the Blind BBS `ProofGen` procedure will also
+produce and updated (adjusted) list of indexes which should be used to update
+the |selectiveIndexes| variable in subsequent processing. <span class="note">To
+be updated when IETF API is finalized.</span>
                 </li>
                 <li>
-If |pid| is not empty, compute the |pseudonym| according to the procedures given
+If |featureOption| equals `"pseudonym_issuer_pid"`, compute the |pseudonym|
+according to the procedures given
 in [[CFRG-Pseudonym-BBS-Signature]],
-and set `bbsProof` to the value computed by the `ProofGen` procedure from
-[[CFRG-Pseudonym-BBS-Signature]], where `PK` is the original issuers public key,
-`signature` is the
-`bbsSignature`, `header` is the `bbsHeader`, `ph` is the  `presentationHeader`
-`messages` is `bbsMessages`, `disclosed_indexes` is `selectiveIndexes`, and
-|pseudonym| is the `pseudonym`. This is for both "pseudonym with issuer known
-pid" and "pseudonym with hidden pid" cases.
+and set |bsProof| to the value computed by the `ProofGen` procedure from
+[[CFRG-Pseudonym-BBS-Signature]], where |PK| is the original issuers public key,
+|signature| is the
+|bbsSignature|, |header| is the |bbsHeader|, |ph| is the  |presentationHeader|
+|messages| is |bbsMessages|, |disclosed_indexes| is |selectiveIndexes|, and
+|pseudonym| is the `pseudonym`. This is for the
+<a href="#pseudonyms-with-issuer-known-pid">Pseudonyms with Issuer-known PID</a>
+feature option. <span class="note">To be updated when IETF API is finalized.
+</span>
+                </li>
+                <li>
+If |featureOption| equals `"pseudonym_hidden_pid"`, compute the |pseudonym|
+according to the procedures given
+in [[CFRG-Pseudonym-BBS-Signature]],
+and set |bsProof| to the value computed by the `ProofGen` procedure from
+[[CFRG-Pseudonym-BBS-Signature]], where |PK| is the original issuers public key,
+|signature| is the
+|bbsSignature|, |header| is the |bbsHeader|, |ph| is the  |presentationHeader|
+|messages| is |bbsMessages|, |disclosed_indexes| is |selectiveIndexes|,
+|commitment_with_proof|, |pid|, |proverBlind|, |signer_blind|, and
+|pseudonym| is the `pseudonym`. This is for the
+<a href="#pseudonyms-with-hidden-pid">Pseudonyms with Hidden PID</a>
+feature option. <span class="note">To be updated when IETF API is finalized.
+</span>
                 </li>
               </ol>
             </li>
 
 
             <li>
-Initialize |revealDocument| to the result of the "selectJsonLd"
-algorithm, passing `document`, and `combinedPointers` as `pointers`.
+Initialize |revealDocument| to the result of the "selectJsonLd" algorithm from
+[[DI-ECDSA]], passing `document`, and `combinedPointers` as `pointers`.
             </li>
             <li>
 Run the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] on
@@ -880,8 +903,8 @@ value associated with `inputLabel` as a key in `labelMap` as the value.
               </ol>
             </li>
             <li>
-Return an object with properties matching `bbsProof`, "verifierLabelMap" for `labelMap`,
-`mandatoryIndexes`, `selectiveIndexes`, `revealDocument`, and |pseudonym|, if
+Return an object with properties matching |bbsProof|, "verifierLabelMap" for |labelMap|,
+|mandatoryIndexes|, |selectiveIndexes|, |revealDocument|, and |pseudonym|, if
 computed.
             </li>
           </ol>

--- a/index.html
+++ b/index.html
@@ -1077,9 +1077,21 @@ in this section also include the verification of such a data integrity proof.
           <p>
 The following algorithm specifies how to create a [=data integrity proof=] given
 an <a>unsecured data document</a>. Required inputs are an
-<a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of proof
-options ([=map=] |options|). A [=data integrity proof=] ([=map=]), or an error,
+<a>unsecured data document</a> ([=map=] |unsecuredDocument|), a set of proof
+options ([=map=] |options|), an array of mandatory JSON pointers
+(|mandatoryPointers|), a |featureOption| indicator parameter, and, depending on
+the |featureOption|, a |commitment_with_proof| byte array.
+A [=data integrity proof=] ([=map=]), or an error,
 is produced as output.
+          </p>
+          <p>
+The |featureOption| parameter is used to indicate which optional feature, if
+any, is being used. It can take one of the following values `"baseline"`,
+`"anonymous_holder_binding"`, `"pseudonym_issuer_pid"`, or
+`"pseudonym_hidden_pid"`. Note that `"baseline"` is used to denote the case of
+no optional features. In the cases where the |featureOption| is set to
+`"anonymous_holder_binding"` or `"pseudonym_hidden_pid"`, the
+|commitment_with_proof| input MUST be supplied.
           </p>
 
           <ol class="algorithm">
@@ -1103,8 +1115,9 @@ passed as a parameters.
             </li>
             <li>
 Let |proofBytes| be the result of running the algorithm in Section
-[[[#base-proof-serialization-bbs-2023]]] with |hashData| and
-|options| passed as parameters.
+[[[#base-proof-serialization-bbs-2023]]] with |hashData|,
+|options|, |featureOption|, and if required |commitment_with_proof passed as
+parameters.
             </li>
             <li>
 Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">

--- a/index.html
+++ b/index.html
@@ -590,20 +590,72 @@ both.
           <p>
 The following algorithm serializes the base proof value, including the
 BBS signature, HMAC key, and mandatory pointers.
-The required inputs are a base signature |bbsSignature|,
-an HMAC key |hmacKey|, and an array of
-|mandatoryPointers|.
+The required inputs are a base signature |bbsSignature|, |bbsHeader|,
+|publicKey|, an HMAC key |hmacKey|, an array of
+|mandatoryPointers|, |featureOption|,and depending on
+the |featureOption| value the |pid|, and |signer_blind| values.
 A single <em>base proof</em> string value is produced as output.
           </p>
 
           <ol class="algorithm">
             <li>
-Initialize a byte array, `proofValue`, that starts with the BBS base proof
-header bytes `0xd9`, `0x5d`, and `0x02`.
+Depending upon the value of the |featureOption| set up the |proofValue| as
+follows.
             </li>
             <li>
+If |proofValue| equals `"baseline"`:
+              <ol class="algorithm">
+                <li>
+Initialize a byte array, |proofValue|, that starts with the BBS base proof
+header bytes `0xd9`, `0x5d`, and `0x02`.
+                </li>
+                <li>
 Initialize |components| to an array with five elements containing the values of:
 |bbsSignature|, |bbsHeader|, |publicKey|, |hmacKey|, and |mandatoryPointers|.
+                </li>
+              </ol>
+            </li>
+            <li>
+If |proofValue| equals `"anonymous_holder_binding"`:
+              <ol class="algorithm">
+                <li>
+Initialize a byte array, |proofValue|, that starts with the BBS base proof
+header bytes `0xd9`, `0x5d`, and `0x04`.
+                </li>
+                <li>
+Initialize |components| to an array with five elements containing the values of:
+|bbsSignature|, |bbsHeader|, |publicKey|, |hmacKey|, |mandatoryPointers|,
+|signerBlind|.
+                </li>
+              </ol>
+            </li>
+            <li>
+If |proofValue| equals `"pseudonym_issuer_pid"`:
+              <ol class="algorithm">
+                <li>
+Initialize a byte array, |proofValue|, that starts with the BBS base proof
+header bytes `0xd9`, `0x5d`, and `0x06`.
+                </li>
+                <li>
+Initialize |components| to an array with five elements containing the values of:
+|bbsSignature|, |bbsHeader|, |publicKey|, |hmacKey|, |mandatoryPointers|,
+|pid|.
+                </li>
+              </ol>
+            </li>
+            <li>
+If |proofValue| equals `"pseudonym_hidden_pid"`:
+              <ol class="algorithm">
+                <li>
+Initialize a byte array, |proofValue|, that starts with the BBS base proof
+header bytes `0xd9`, `0x5d`, and `0x08`.
+                </li>
+                <li>
+Initialize |components| to an array with five elements containing the values of:
+|bbsSignature|, |bbsHeader|, |publicKey|, |hmacKey|, |mandatoryPointers|,
+|signerBlind|.
+                </li>
+              </ol>
             </li>
             <li>
 CBOR-encode |components| per [[RFC8949]] where CBOR tagging MUST NOT be used on
@@ -1357,7 +1409,7 @@ cryptographically random 32 byte |pid| value. Compute the
 with appropriate key material, `bbsHeader` for the `header`, `bbsMessages`
 for the `messages`, and |pid| for the `pid`. Retain the |pid| value for use when
 calling <a href="#serializebaseproofvalue"></a> below.
-This provides for <a href="#pseudonym-with-issuer-known-pid">Pseudonym with
+This provides for <a href="#pseudonyms-with-issuer-known-pid">Pseudonym with
 Issuer-known PID</a> feature.
                 </li>
                 <li>
@@ -1368,7 +1420,7 @@ for the `header`, `bbsMessages` for the `messages`, and |commitment_with_proof|
 for the `commitment_with_proof`. If the signing procedure uses the optional
 |signer_blind| parameter retain this value for use when calling
 <a href="#serializebaseproofvalue"></a> below.
-This provides for the <a href="#pseudonym-with-hidden-pid">Pseudonym with
+This provides for the <a href="#pseudonyms-with-hidden-pid">Pseudonym with
   Hidden PID</a> feature.
                 </li>
               </ol>

--- a/index.html
+++ b/index.html
@@ -1451,20 +1451,40 @@ The derived proof is to be given to the <a>verifier</a>. The inputs include a
 JSON-LD document (|document|), a BBS base proof
 (|proof|), an array of JSON pointers to use to selectively disclose
 statements (|selectivePointers|), an OPTIONAL BBS
-|presentationHeader| (a byte array), an OPTIONAL
-|commitment_with_proof| (a byte array), an OPTIONAL |pid| value (a byte array),
+|presentationHeader| (a byte array), a |featureOption| parameter, additional
+parameters supporting the |featureOption| selected (see below),
 and any custom JSON-LD API options,
 such as a document loader. A single <em>selectively revealed document</em>
 value, represented as an object, is produced as output.
           </p>
-
+          <p>
+In the case where |featureOption| equals `"anonymous_holder_binding"` the
+REQUIRED additional inputs are |holderSecret| and |proverBlind|. These would
+have been precomputed by the holder. See
+<a href="#anonymous-holder-binding">Anonymous Holder Binding</a> for background
+information.
+          </p>
+          <p>
+In the case where |featureOption| equals `"pseudonym_issuer_pid"` the REQUIRED
+additional input is the |verifier_id| which is communicated to the holder by the
+verifier. See <a href="#pseudonyms-with-issuer-known-pid">Pseudonyms with
+Issuer-known PID</a> for background information.
+          </p>
+          <p>
+In the case where |featureOption| equals `"pseudonym_hidden_pid"` the REQUIRED
+additional inputs are the |pid|, |proverBlind| (both known to
+holder),  |verifier_id| which is communicated to the holder by the verifier. See
+See <a href="#pseudonyms-with-hidden-pid">Pseudonyms with
+Hidden PID</a> for background information.
+          </p>
           <ol>
             <li>
-Initialize `bbsProof`,  `labelMap`, `mandatoryIndexes`, `selectiveIndexes`, and
-`revealDocument` to the values associated with their
+Initialize |bbsProof|,  |labelMap|, |mandatoryIndexes|, |selectiveIndexes|, and
+|revealDocument| to the values associated with their
 property names in the object returned when calling the algorithm in
-Section <a href="#createdisclosuredata"></a>, passing the `document`, `proof`,
-`selectivePointers`, `presentationHeader`, and any custom JSON-LD API options,
+Section <a href="#createdisclosuredata"></a>, passing the |document|, |proof|,
+|selectivePointers|, |presentationHeader|, |featureOption|, required additional
+inputs based on the |featureOption|, and any custom JSON-LD API options,
 such as a document loader.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -1116,7 +1116,7 @@ passed as a parameters.
             <li>
 Let |proofBytes| be the result of running the algorithm in Section
 [[[#base-proof-serialization-bbs-2023]]] with |hashData|,
-|options|, |featureOption|, and if required |commitment_with_proof passed as
+|options|, |featureOption|, and if required |commitment_with_proof| passed as
 parameters.
             </li>
             <li>
@@ -1303,10 +1303,13 @@ algorithm is designed to be used in conjunction with the algorithms defined
 in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
 <a data-cite="vc-data-integrity#algorithms">
 Section 4: Algorithms</a>. Required inputs are
-cryptographic hash data (|hashData|) and
-<em>proof options</em> (|options|).
-Optional inputs include a |commitment_with_proof| byte array and/or a
-|use_pseudonyms| boolean.
+cryptographic hash data (|hashData|),
+<em>proof options</em> (|options|), |featureOption|, and if required
+|commitment_with_proof|.
+If |featureOption| is set to `"anonymous_holder_binding"` or
+`"pseudonym_hidden_pid"`, the
+|commitment_with_proof| input MUST be supplied and otherwise an error should be
+returned.
 The <em>proof options</em> MUST contain a type identifier for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
 cryptographic suite</a> (|type|) and MAY contain a cryptosuite
@@ -1330,50 +1333,52 @@ Initialize `bbsMessages` to an array of byte arrays containing the values in the
             </li>
             <li>
 Compute the `bbsSignature` using the procedures below, dependent on the values
-of |commitment_with_proof| and |use_pseudonyms| options.
+of |featureOption|.
               <ol class="algorithm">
                 <li>
-If |commitment_with_proof| is empty and |use_pseudonyms| is false, compute the
+If |featureOption| equals `"baseline"`, compute the
 `bbsSignature` using the `Sign` procedure of [[CFRG-BBS-Signature]],
 with appropriate key material, `bbsHeader` for the `header`, and `bbsMessages`
 for the `messages`.
                 </li>
                 <li>
-If |commitment_with_proof| is not empty and |use_pseudonyms| is false, compute the
+If |featureOption| equals `"anonymous_holder_binding"` , compute the
 `bbsSignature` using the `Sign` procedure of [[CFRG-Blind-BBS-Signature]],
 with appropriate key material, `bbsHeader` for the `header`, and `bbsMessages`
 for the `messages`. If the signing procedure uses the optional |signer_blind|
 parameter, retain this value for use when calling
 <a href="#serializebaseproofvalue"></a> (below). This provides for the
-"anonymous holder binding" feature.
+<a href="#anonymous-holder-binding">Anonymous Holder Binding</a> feature.
                 </li>
                 <li>
-If |commitment_with_proof| is empty and |use_pseudonyms| is true, generate a
+If |featureOption| equals `"pseudonym_issuer_pid"`, generate a
 cryptographically random 32 byte |pid| value. Compute the
 `bbsSignature` using the `Sign` procedure of [[CFRG-Pseudonym-BBS-Signature]],
 with appropriate key material, `bbsHeader` for the `header`, `bbsMessages`
 for the `messages`, and |pid| for the `pid`. Retain the |pid| value for use when
 calling <a href="#serializebaseproofvalue"></a> below.
-This provides for "pseudonym with issuer known pid".
+This provides for <a href="#pseudonym-with-issuer-known-pid">Pseudonym with
+Issuer-known PID</a> feature.
                 </li>
                 <li>
-If |commitment_with_proof| is not empty and |use_pseudonyms| is true, compute
+If |featureOption| equals `"pseudonym_hidden_pid"`, compute
 the `bbsSignature` using the `Sign` procedure of
 [[CFRG-Pseudonym-BBS-Signature]], with appropriate key material, `bbsHeader`
 for the `header`, `bbsMessages` for the `messages`, and |commitment_with_proof|
 for the `commitment_with_proof`. If the signing procedure uses the optional
 |signer_blind| parameter retain this value for use when calling
 <a href="#serializebaseproofvalue"></a> below.
-This provides for the "pseudonym with hidden pid" feature.
+This provides for the <a href="#pseudonym-with-hidden-pid">Pseudonym with
+  Hidden PID</a> feature.
                 </li>
               </ol>
             </li>
             <li>
 Initialize `proofValue to the result of calling the algorithm in Section
-<a href="#serializebaseproofvalue"></a>, passing `bbsSignature`, `bbsHeader`,
-`publicKey`, `hmacKey`, `mandatoryPointers`, `pid`, and `signer_blind` values as
-paramters. Use empty byte arrays for `pid` and `signer_blind` if they are not
-used.
+<a href="#serializebaseproofvalue"></a>, passing |bbsSignature|, |bbsHeader|,
+|publicKey|, |hmacKey|, |mandatoryPointers|, |featureOption|, and depending on
+the |featureOption| value and signing options the |pid|, and |signer_blind|
+values as paramters.
 Note `publicKey` is a byte array of the public key, encoded according to
 [[CFRG-BBS-SIGNATURE]].
             </li>

--- a/index.html
+++ b/index.html
@@ -1205,9 +1205,9 @@ performed in parallel; it only needs to be completed before this algorithm needs
 to use the `proofHash` value.
             </li>
             <li>
-Initialize `bbsProof`, `labelMap`, `mandatoryIndexes`, `selectiveIndexes`,
-`presentationHeader`, and `pseudonym` to the values associated with their
-property names in the
+Initialize |bbsProof|, |labelMap|, |mandatoryIndexes|, |selectiveIndexes|,
+|presentationHeader|,  |featureOption|, and, possibly, |pseudonym| to the values
+associated with their property names in the
 object returned when calling the algorithm in Section
 <a href="#parsederivedproofvalue"></a>, passing `proofValue` from `proof`.
             </li>
@@ -1245,8 +1245,9 @@ Initialize `mandatoryHash` to the result of calling the "`hashMandatory`"
 primitive, passing `mandatory`.
             </li>
             <li>
-Return an object with properties matching `baseSignature`, `proofHash`,
-`nonMandatory`, `mandatoryHash`, `selectiveIndexes`, and `pseudonym`.
+Return an object with properties matching |baseSignature|, |proofHash|,
+|nonMandatory|, |mandatoryHash|, |selectiveIndexes|, |featureOption|, and,
+possibly |pseudonym|.
             </li>
           </ol>
 

--- a/index.html
+++ b/index.html
@@ -1191,58 +1191,59 @@ BBS-protected <a>verifiable credential</a>. The inputs include a JSON-LD
 document (|document|), a BBS disclosure proof (|proof|),
 and any custom JSON-LD API options (such as a document loader). A single
 <em>verify data</em> object value is produced as output containing the following
-fields: `bbsProof`, `proofHash`, `mandatoryHash`, `selectedIndexes`,
-`presentationHeader`, and `nonMandatory`.
+fields: |bbsProof|, |proofHash|, |mandatoryHash|, |selectedIndexes|,
+|presentationHeader|, |nonMandatory|, |featureOption|, and, possibly,
+|pseudonym|.
           </p>
 
           <ol class="algorithm">
             <li>
-Initialize `proofHash` to the result of performing RDF Dataset Canonicalization
+Initialize |proofHash| to the result of performing RDF Dataset Canonicalization
 [[RDF-CANON]] on the proof options, i.e., the proof  portion of the document
-with the `proofValue` removed. The hash used is the same as that used in
+with the |proofValue| removed. The hash used is the same as that used in
 the signature algorithm, i.e., SHA-256. Note: This step can be
 performed in parallel; it only needs to be completed before this algorithm needs
-to use the `proofHash` value.
+to use the |proofHash| value.
             </li>
             <li>
 Initialize |bbsProof|, |labelMap|, |mandatoryIndexes|, |selectiveIndexes|,
 |presentationHeader|,  |featureOption|, and, possibly, |pseudonym| to the values
 associated with their property names in the
 object returned when calling the algorithm in Section
-<a href="#parsederivedproofvalue"></a>, passing `proofValue` from `proof`.
+<a href="#parsederivedproofvalue"></a>, passing |proofValue| from |proof|.
             </li>
             <li>
-Initialize `labelMapFactoryFunction` to the result of calling the
+Initialize |labelMapFactoryFunction| to the result of calling the
 "`createLabelMapFunction`" algorithm.
             </li>
             <li>
-Initialize `nquads` to the result of calling the "`labelReplacementCanonicalize`"
-algorithm of [[DI-ECDSA]], passing `document`, `labelMapFactoryFunction`, and
+Initialize |nquads| to the result of calling the "`labelReplacementCanonicalize`"
+algorithm of [[DI-ECDSA]], passing |document|, |labelMapFactoryFunction|, and
 any custom
 JSON-LD API options. Note: This step transforms the document into an array of
-canonical N-Quads with pseudorandom blank node identifiers based on `labelMap`.
+canonical N-Quads with pseudorandom blank node identifiers based on |labelMap|.
             </li>
             <li>
-Initialize `mandatory` to an empty array.
+Initialize |mandatory| to an empty array.
             </li>
             <li>
-Initialize `nonMandatory` to an empty array.
+Initialize |nonMandatory| to an empty array.
             </li>
             <li>
-For each entry (`index`, `nq`) in `nquads`, separate the N-Quads into mandatory
+For each entry (|index|, |nq|) in |nquads|, separate the N-Quads into mandatory
 and non-mandatory categories:
               <ol class="algorithm">
                 <li>
-If `mandatoryIndexes` includes `index`, add `nq` to `mandatory`.
+If |mandatoryIndexes| includes |index|, add |nq| to |mandatory|.
                 </li>
                 <li>
-Otherwise, add `nq` to `nonMandatory`.
+Otherwise, add |nq| to |nonMandatory|.
                 </li>
               </ol>
             </li>
             <li>
-Initialize `mandatoryHash` to the result of calling the "`hashMandatory`"
-primitive, passing `mandatory`.
+Initialize |mandatoryHash| to the result of calling the "`hashMandatory`"
+primitive, passing |mandatory|.
             </li>
             <li>
 Return an object with properties matching |baseSignature|, |proofHash|,
@@ -1687,41 +1688,49 @@ removed.
 Let |proof| be the value of |securedDocument|.|proof|.
             </li>
             <li>
-Initialize `bbsProof`, `proofHash`, `mandatoryHash`, `selectedIndexes`,
-`presentationHeader`, `pseudonym`, and `nonMandatory` to the values associated
+Initialize |bbsProof|, |proofHash|, |mandatoryHash|, |selectedIndexes|,
+|presentationHeader|, |nonMandatory|, |featureOption|, and, possibly,
+|pseudonym|, to the values associated
 with their property names in the object returned when calling the algorithm in
 Section <a href="#createverifydata"></a>, passing the |unsecuredDocument|,
 |proof|, and any custom JSON-LD API options (such as a document loader).
             </li>
             <li>
-Initialize `bbsHeader` to the concatenation of `proofHash` and `mandatoryHash`
-in that order. Initialize `disclosedMessages` to an array of byte arrays
-obtained from the UTF-8 encoding of the elements of the `nonMandatory` array.
+Initialize |bbsHeader| to the concatenation of |proofHash| and |mandatoryHash|
+in that order. Initialize |disclosedMessages| to an array of byte arrays
+obtained from the UTF-8 encoding of the elements of the |nonMandatory| array.
             </li>
             <li>
 Initialize |verified| to the result of applying the verification
-algorithm below, depending on whether the |pseudonym| value is empty.
+algorithm below, depending the |featureOption| value.
             <ol class="algorithm">
               <li>
-If the |pseudonym| value is empty, initialize |verified| to the result of
+If the |featureOption| equals `"baseline"`, Initialize |verified| to the result of
 applying the verification algorithm `ProofVerify(PK, proof, header, ph,
 disclosed_messages, disclosed_indexes)` of [[CFRG-BBS-SIGNATURE]] with `PK` set
 as the public key of the original issuer, `proof` set as `bbsProof`, `header`
 set as `bbsHeader`, `disclosed_messages` set as `disclosedMessages`, `ph` set as
-`presentationHeader`, and `disclosed_indexes` set as `selectiveIndexes`. This
-applies to the regular BBS proof case as well as "anonymous holder binding"
-case.
+`presentationHeader`, and `disclosed_indexes` set as `selectiveIndexes`.
               </li>
               <li>
-If the |pseudonym| value is not empty, initialize |verified| to the result of
-applying the verification algorithm `PseudonymProofVerify(PK, proof, header, ph,
-disclosed_messages, disclosed_indexes, pseudonym)` of
-[[CFRG-Pseudonym-BBS-Signature]], with `PK` set as the public key of the
-original issuer, `proof` set as `bbsProof`, `header` set as `bbsHeader`,
-`disclosed_messages` set as `disclosedMessages`, `ph` set as
-`presentationHeader`, `disclosed_indexes` set as `selectiveIndexes`, and
-`pseudonym`. This applies to the "pseudonym with issuer known pid" and
-"pseudonym with hidden pid" cases.
+If the |featureOption| equals `"anonymous_holder_binding"`, Initialize |verified| to the result of
+applying the verification algorithm `ProofVerify` algorithm of
+[[CFRG-Blind-BBS-Signature]].  <span class="note">To
+  be updated when IETF API is finalized.</span>
+              </li>
+              <li>
+If the |featureOption| equals `"pseudonym_issuer_pid"`, initialize |verified|
+to the result of
+applying the verification algorithm `PseudonymProofVerify()` of
+[[CFRG-Pseudonym-BBS-Signature]]. <span class="note">To be updated when IETF
+API is finalized.</span>
+              </li>
+              <li>
+If the |featureOption| equals `"pseudonym_hidden_pid"`, initialize |verified|
+to the result of
+applying the verification algorithm `PseudonymHiddenPidProofVerify()` of
+[[CFRG-Pseudonym-BBS-Signature]]. <span class="note">To be updated when IETF
+API is finalized.</span>
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -592,14 +592,14 @@ The following algorithm serializes the base proof value, including the
 BBS signature, HMAC key, and mandatory pointers.
 The required inputs are a base signature |bbsSignature|, |bbsHeader|,
 |publicKey|, an HMAC key |hmacKey|, an array of
-|mandatoryPointers|, |featureOption|,and depending on
+|mandatoryPointers|, |featureOption|, and depending on
 the |featureOption| value the |pid|, and |signer_blind| values.
 A single <em>base proof</em> string value is produced as output.
           </p>
 
           <ol class="algorithm">
             <li>
-Depending upon the value of the |featureOption| set up the |proofValue| as
+Depending upon the value of the |featureOption|, set up the |proofValue| as
 follows.
             </li>
             <li>
@@ -623,8 +623,8 @@ Initialize a byte array, |proofValue|, that starts with the BBS base proof
 header bytes `0xd9`, `0x5d`, and `0x04`.
                 </li>
                 <li>
-Initialize |components| to an array with five elements containing the values of:
-|bbsSignature|, |bbsHeader|, |publicKey|, |hmacKey|, |mandatoryPointers|,
+Initialize |components| to an array with six elements containing the values of:
+|bbsSignature|, |bbsHeader|, |publicKey|, |hmacKey|, |mandatoryPointers|, and
 |signerBlind|.
                 </li>
               </ol>
@@ -637,8 +637,8 @@ Initialize a byte array, |proofValue|, that starts with the BBS base proof
 header bytes `0xd9`, `0x5d`, and `0x06`.
                 </li>
                 <li>
-Initialize |components| to an array with five elements containing the values of:
-|bbsSignature|, |bbsHeader|, |publicKey|, |hmacKey|, |mandatoryPointers|,
+Initialize |components| to an array with six elements containing the values of:
+|bbsSignature|, |bbsHeader|, |publicKey|, |hmacKey|, |mandatoryPointers|, and
 |pid|.
                 </li>
               </ol>
@@ -651,8 +651,8 @@ Initialize a byte array, |proofValue|, that starts with the BBS base proof
 header bytes `0xd9`, `0x5d`, and `0x08`.
                 </li>
                 <li>
-Initialize |components| to an array with five elements containing the values of:
-|bbsSignature|, |bbsHeader|, |publicKey|, |hmacKey|, |mandatoryPointers|,
+Initialize |components| to an array with six elements containing the values of:
+|bbsSignature|, |bbsHeader|, |publicKey|, |hmacKey|, |mandatoryPointers|, and
 |signerBlind|.
                 </li>
               </ol>
@@ -698,30 +698,30 @@ an error if it does not.
             </li>
             <li>
 Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
-substring following the leading `u` in `proofValue`.
+substring that follows the leading `u` in `proofValue`.
             </li>
             <li>
 Check that the BBS base proof starts with an allowed header value and set the
 |featureOption| variable as follows:
               <ol class="algorithm">
                 <li>
-If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x02` set
+If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x02`, set
 |featureOption| to `"baseline"`.
                 </li>
                 <li>
-If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x04` set
+If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x04`, set
 |featureOption| to `"anonymous_holder_binding"`.
                 </li>
                 <li>
-If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x06` set
+If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x06`, set
 |featureOption| to `"pseudonym_issuer_pid"`.
                 </li>
                 <li>
-If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x08` set
+If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x08`, set
 |featureOption| to `"pseudonym_hidden_pid"`.
                 </li>
                 <li>
-If the |decodedProofValue| starts with any other three byte sequence throw an
+If the |decodedProofValue| starts with any other three byte sequence, throw an
 error.
                 </li>
               </ol>
@@ -732,30 +732,30 @@ Initialize `components` to an array that is the result of CBOR-decoding the
 bytes that follow the three-byte BBS base proof header.
             </li>
             <li>
-Based on the value of |featureOption| return an object based on |components|
+Based on the value of |featureOption|, return an object based on |components|,
 as follows:
               <ol class="algorithm">
                 <li>
-If |featureOption| equals `"baseline"` set the property names for the object
+If |featureOption| equals `"baseline"`, set the property names for the object
 based on |components| to "bbsSignature", "bbsHeader", "publicKey", "hmacKey",
-"mandatoryPointers" in that order and add |featureOption| as a property.
+and "mandatoryPointers", in that order, and add |featureOption| as a property.
                 </li>
                 <li>
-If |featureOption| equals `"anonymous_holder_binding"` set the property names
+If |featureOption| equals `"anonymous_holder_binding"`, set the property names
 for the object based on |components| to "bbsSignature", "bbsHeader",
-"publicKey", "hmacKey", "mandatoryPointers", "signer_blind" in that order and
+"publicKey", "hmacKey", "mandatoryPointers", and "signer_blind", in that order, and
 add |featureOption| as a property.
                 </li>
                 <li>
-If |featureOption| equals `"pseudonym_issuer_pid"` set the property names
+If |featureOption| equals `"pseudonym_issuer_pid"`, set the property names
 for the object based on |components| to "bbsSignature", "bbsHeader",
-"publicKey", "hmacKey", "mandatoryPointers", "pid" in that order and
+"publicKey", "hmacKey", "mandatoryPointers", and "pid", in that order, and
 add |featureOption| as a property.
                 </li>
                 <li>
-If |featureOption| equals `"pseudonym_hidden_pid"` set the property names
+If |featureOption| equals `"pseudonym_hidden_pid"`, set the property names
 for the object based on |components| to "bbsSignature", "bbsHeader",
-"publicKey", "hmacKey", "mandatoryPointers", "signer_blind" in that order and
+"publicKey", "hmacKey", "mandatoryPointers", and "signer_blind", in that order, and
 add |featureOption| as a property.
                 </li>
               </ol>
@@ -815,7 +815,7 @@ canonicalizeAndGroup</a> of the [[DI-ECDSA]] specification, passing |document|
 |labelMapFactoryFunction|,
 |groupDefinitions|, and any custom JSON-LD
 API options. Note: This step transforms the document into an array of canonical
-N-Quads whose order has been shuffled based on 'hmac' applied blank node
+N-Quads whose order has been shuffled based on 'hmac'-applied blank node
 identifiers, and groups
 the N-Quad strings according to selections based on JSON pointers.
             </li>
@@ -879,14 +879,14 @@ If |featureOption| equals `"anonymous_holder_binding"`,
 set `bbsProof` to the value computed by the `ProofGen` procedure from
 [[CFRG-Blind-BBS-Signature]], where |PK| is the original issuers public key,
 |signature| is the
-|bbsSignature|, |header| is the |bbsHeader|, |ph| is the  |presentationHeader|,
+|bbsSignature|, |header| is the |bbsHeader|, |ph| is the |presentationHeader|,
 |messages| is |bbsMessages|, |disclosed_indexes| is |selectiveIndexes|,
 `commitment_with_proof`, and `signer_blind`. The holder will also furnish its
 |holder_secret|, and |proverBlind| that was used to compute the
 |commitment_with_proof|. This is the
 <a href="#anonymous-holder-binding">Anonymous Holder Binding</a> feature option.
-In addition to the |bbsProof| the Blind BBS `ProofGen` procedure will also
-produce and updated (adjusted) list of indexes which should be used to update
+In addition to the |bbsProof|, the Blind BBS `ProofGen` procedure will also
+produce an updated (adjusted) list of indexes which should be used to update
 the |selectiveIndexes| variable in subsequent processing. <span class="note">To
 be updated when IETF API is finalized.</span>
                 </li>
@@ -897,7 +897,7 @@ in [[CFRG-Pseudonym-BBS-Signature]],
 and set |bsProof| to the value computed by the `ProofGen` procedure from
 [[CFRG-Pseudonym-BBS-Signature]], where |PK| is the original issuers public key,
 |signature| is the
-|bbsSignature|, |header| is the |bbsHeader|, |ph| is the  |presentationHeader|
+|bbsSignature|, |header| is the |bbsHeader|, |ph| is the |presentationHeader|
 |messages| is |bbsMessages|, |disclosed_indexes| is |selectiveIndexes|, and
 |pseudonym| is the `pseudonym`. This is for the
 <a href="#pseudonyms-with-issuer-known-pid">Pseudonyms with Issuer-known PID</a>
@@ -1207,7 +1207,7 @@ to use the |proofHash| value.
             </li>
             <li>
 Initialize |bbsProof|, |labelMap|, |mandatoryIndexes|, |selectiveIndexes|,
-|presentationHeader|,  |featureOption|, and, possibly, |pseudonym| to the values
+|presentationHeader|, |featureOption|, and, possibly, |pseudonym| to the values
 associated with their property names in the
 object returned when calling the algorithm in Section
 <a href="#parsederivedproofvalue"></a>, passing |proofValue| from |proof|.
@@ -1285,7 +1285,7 @@ The |featureOption| parameter is used to indicate which optional feature, if
 any, is being used. It can take one of the following values `"baseline"`,
 `"anonymous_holder_binding"`, `"pseudonym_issuer_pid"`, or
 `"pseudonym_hidden_pid"`. Note that `"baseline"` is used to denote the case of
-no optional features. In the cases where the |featureOption| is set to
+no optional features. If |featureOption| is set to
 `"anonymous_holder_binding"` or `"pseudonym_hidden_pid"`, the
 |commitment_with_proof| input MUST be supplied.
           </p>
@@ -1312,7 +1312,7 @@ passed as a parameters.
             <li>
 Let |proofBytes| be the result of running the algorithm in Section
 [[[#base-proof-serialization-bbs-2023]]] with |hashData|,
-|options|, |featureOption|, and if required |commitment_with_proof| passed as
+|options|, |featureOption|, and, if required, |commitment_with_proof| passed as
 parameters.
             </li>
             <li>
@@ -1500,11 +1500,11 @@ in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
 <a data-cite="vc-data-integrity#algorithms">
 Section 4: Algorithms</a>. Required inputs are
 cryptographic hash data (|hashData|),
-<em>proof options</em> (|options|), |featureOption|, and if required
+<em>proof options</em> (|options|), |featureOption|, and, if required,
 |commitment_with_proof|.
 If |featureOption| is set to `"anonymous_holder_binding"` or
 `"pseudonym_hidden_pid"`, the
-|commitment_with_proof| input MUST be supplied and otherwise an error should be
+|commitment_with_proof| input MUST be supplied; if not supplied, an error SHOULD be
 returned.
 The <em>proof options</em> MUST contain a type identifier for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
@@ -1602,22 +1602,22 @@ such as a document loader. A single <em>selectively revealed document</em>
 value, represented as an object, is produced as output.
           </p>
           <p>
-In the case where |featureOption| equals `"anonymous_holder_binding"` the
+If |featureOption| equals `"anonymous_holder_binding"`, the
 REQUIRED additional inputs are |holderSecret| and |proverBlind|. These would
 have been precomputed by the holder. See
 <a href="#anonymous-holder-binding">Anonymous Holder Binding</a> for background
 information.
           </p>
           <p>
-In the case where |featureOption| equals `"pseudonym_issuer_pid"` the REQUIRED
+If |featureOption| equals `"pseudonym_issuer_pid"`, the REQUIRED
 additional input is the |verifier_id| which is communicated to the holder by the
 verifier. See <a href="#pseudonyms-with-issuer-known-pid">Pseudonyms with
 Issuer-known PID</a> for background information.
           </p>
           <p>
-In the case where |featureOption| equals `"pseudonym_hidden_pid"` the REQUIRED
+If |featureOption| equals `"pseudonym_hidden_pid"`, the REQUIRED
 additional inputs are the |pid|, |proverBlind| (both known to
-holder),  |verifier_id| which is communicated to the holder by the verifier. See
+holder), and |verifier_id| which is communicated to the holder by the verifier.
 See <a href="#pseudonyms-with-hidden-pid">Pseudonyms with
 Hidden PID</a> for background information.
           </p>
@@ -1705,7 +1705,7 @@ Initialize |verified| to the result of applying the verification
 algorithm below, depending the |featureOption| value.
             <ol class="algorithm">
               <li>
-If the |featureOption| equals `"baseline"`, Initialize |verified| to the result of
+If the |featureOption| equals `"baseline"`, initialize |verified| to the result of
 applying the verification algorithm `ProofVerify(PK, proof, header, ph,
 disclosed_messages, disclosed_indexes)` of [[CFRG-BBS-SIGNATURE]] with `PK` set
 as the public key of the original issuer, `proof` set as `bbsProof`, `header`
@@ -1713,7 +1713,8 @@ set as `bbsHeader`, `disclosed_messages` set as `disclosedMessages`, `ph` set as
 `presentationHeader`, and `disclosed_indexes` set as `selectiveIndexes`.
               </li>
               <li>
-If the |featureOption| equals `"anonymous_holder_binding"`, Initialize |verified| to the result of
+If the |featureOption| equals `"anonymous_holder_binding"`,
+initialize |verified| to the result of
 applying the verification algorithm `ProofVerify` algorithm of
 [[CFRG-Blind-BBS-Signature]].  <span class="note">To
   be updated when IETF API is finalized.</span>
@@ -1895,12 +1896,12 @@ When the verifier receives the revealed document with derived proof and
       <section class="informative">
         <h3>Optional Feature Summary</h3>
         <p>
-This section provides a summaries of the inputs, outputs, proof serialiation,
+This section provides summaries of the inputs, outputs, proof serialiation,
 tasks, and procedures for "baseline" BBS proofs as well as those for the
-optional features. By <em>baseline</em> BBS we mean BBS base and derived proofs
+optional features. By <em>baseline</em> BBS, we mean BBS base and derived proofs
 without additional features. All the optional features are "additive" in the
-sense that some additional input, task, or, output is generated in
-<em>addition</em> to that of the "baseline" BBS signatures/proofs.
+sense that some additional input, task, or output is generated
+<em>in addition</em> to those of the "baseline" BBS signatures/proofs.
         </p>
         <table class="complex data">
           <caption>Table 1 <em>Issuer Create Base: Inputs and such.</em> </caption>

--- a/index.html
+++ b/index.html
@@ -682,8 +682,8 @@ disclosure base proof value. The required input is a proof value
 six or seven elements, using the names "bbsSignature", "bbsHeader",
 "publicKey",
 "hmacKey", "mandatoryPointers", "featureOption", and possibly optional feature
-parameters "pid" and
-"signer_blind" is produced  as output.
+parameter "pid" or
+"signer_blind", is produced as output.
           </p>
 
           <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -1117,9 +1117,10 @@ starting with "`u`" and ending with the base64url-no-pad-encoded value of
 The following algorithm parses the components of the derived proof value.
 The required input is a derived proof value (|proofValue|). A
 single <em>derived proof value</em> object is produced as output, which
-contains a set of five or six elements, having the names `bbsProof`, `labelMap`,
-`mandatoryIndexes`, `selectiveIndexes`, `presentationHeader`, and the optional
-`pseudonym` parameter.
+contains a set of six or seven elements, having the names "bbsProof",
+"labelMap", "mandatoryIndexes", "selectiveIndexes", "presentationHeader",
+"featureOption", and possibly "pseudonym" depending on the value of the
+|featureOption| parameter.
           </p>
 
           <ol class="algorithm">
@@ -1133,20 +1134,38 @@ it is a `multibase-base64url-no-pad-encoded` value, and throw an error if it doe
 not.
             </li>
             <li>
-Initialize `decodedProofValue` to the result of base64url-no-pad-decoding the
+Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
 substring that follows the leading `u` in `proofValue`.
             </li>
             <li>
-Ensure that the `decodedProofValue` starts with the BBS disclosure proof
-header bytes `0xd9`, `0x5d`, and `0x03`, and throw an error if it does not.
-            </li>
+Check that the BBS disclosure proof starts with an allowed header value and set
+the |featureOption| variable as follows:
+              <ol class="algorithm">
+                <li>
+If the |decodedProofValue| starts with the header bytes `0xd9`, `0x5d`, and
+`0x03`, set |featureOption| to `"baseline"`.
+                </li>
+                <li>
+If the |decodedProofValue| starts with the header bytes `0xd9`, `0x5d`, and
+`0x05`, set |featureOption| to `"anonymous_holder_binding"`.
+                </li>
+                <li>
+If the |decodedProofValue| starts with the header bytes `0xd9`, `0x5d`, and
+`0x07`, set |featureOption| to `"pseudonym_issuer_pid"`.
+                </li>
+                <li>
+If the |decodedProofValue| starts with the header bytes `0xd9`, `0x5d`, and
+`0x09`, set |featureOption| to `"pseudonym_hidden_pid"`.
+                </li>
+              </ol>
+
             <li>
 Initialize `components` to an array that is the result of CBOR-decoding the
 bytes that follow the three-byte BBS disclosure proof header. Ensure the result
 is an array of five or six elements —
 a byte array, a map of integers to integers, an
-array of integers, another array of integers, and a byte array; otherwise, throw
-an error.
+array of integers, another array of integers, and one or two byte arrays;
+otherwise, throw an error.
             </li>
             <li>
 Replace the second element in `components` using the result of calling the
@@ -1155,8 +1174,9 @@ second element of `components` as `compressedLabelMap`.
             </li>
             <li>
 Return <em>derived proof value</em> as an object with properties set to the five
-elements, using the names `bbsProof`, `labelMap`, `mandatoryIndexes`,
-`selectiveIndexes`, `presentationHeader`, and optional `pseudonym`, respectively.
+elements, using the names "bbsProof", "labelMap", "mandatoryIndexes",
+"selectiveIndexes", "presentationHeader", and optional "pseudonym", respectively.
+In addition, add |featureOption| and its value to the object.
             </li>
           </ol>
 

--- a/index.html
+++ b/index.html
@@ -1607,8 +1607,9 @@ When the verifier receives the revealed document with derived proof and
 [[CFRG-Pseudonym-BBS-Signature]].
         </p>
       </section>
-      <h3>Pseudonyms with Hidden PID</h3>
-      <p>
+      <section>
+        <h3>Pseudonyms with Hidden PID</h3>
+        <p>
 This feature is a privacy preserving enhancement that allows a verifier that has
 seen a selectively revealed document with derived proof from a holder to
 recognize that the same holder is presenting a new selectively revealed document
@@ -1648,7 +1649,192 @@ When the verifier receives the revealed document with derived proof and
 |pseudonym|, they use the proof verification procedures of
 [[CFRG-Pseudonym-BBS-Signature]].
         </p>
-    </section>
+      </section>
+      <section class="informative">
+        <h3>Optional Feature Summary</h3>
+        <p>
+This section provides a summaries of the inputs, outputs, proof serialiation,
+tasks, and procedures for "baseline" BBS proofs as well as those for the
+optional features. By <em>baseline</em> BBS we mean BBS base and derived proofs
+without additional features. All the optional features are "additive" in the
+sense that some additional input, task, or, output is generated in
+<em>addition</em> to that of the "baseline" BBS signatures/proofs.
+        </p>
+        <table class="complex data">
+          <caption>Table 1 <em>Issuer Create Base: Inputs and such.</em> </caption>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Tasks</th>
+              <th>Inputs</th>
+              <th>Signing Algorithm</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Baseline BBS</td>
+              <td><em>baseline</em>: BBS signature generation from VC</td>
+              <td> <em>baseline</em>: document, proof options, key material, mandatory pointers</td>
+              <td>BBS</td>
+            </tr>
+            <tr>
+              <td>Anonymous Holder Binding</td>
+              <td><em>baseline</em> + selected index adjustment</td>
+              <td><em>baseline</em> + commitment with proof to holder secret from holder</td>
+              <td>Blind BBS</td>
+            </tr>
+            <tr>
+              <td>Pseudonym with Issuer Pid</td>
+              <td><em>baseline</em> + Generate pid</td>
+              <td><em>baseline</em></td>
+              <td>Pseudonym BBS</td>
+            </tr>
+            <tr>
+              <td>Pseudonym with Hidden Pid</td>
+              <td><em>baseline</em> + selected index adjustment</td>
+              <td><em>baseline</em> + commitment with proof to secret pid from holder</td>
+              <td>Pseudonym/Blind BBS</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <table class="complex data">
+          <caption>Table 2 <em>Issuer Create Base: Headers and Serialization.</em> </caption>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Proof Header Bytes</th>
+              <th>Serialized Output</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Baseline BBS</td>
+              <td>`0xd9`, `0x5d`, and `0x02`</td>
+              <td><em>baseline</em>: bbsSignature, bbsHeader, publicKey, hmacKey, and mandatoryPointers</td>
+            </tr>
+            <tr>
+              <td>Anonymous Holder Binding</td>
+              <td>`0xd9`, `0x5d`, and `0x04`</td>
+              <td><em>baseline</em> + signerBlind</td>
+            </tr>
+            <tr>
+              <td>Pseudonym with Issuer Pid</td>
+              <td>`0xd9`, `0x5d`, and `0x06`</td>
+              <td> <em>baseline</em> + pid</td>
+            </tr>
+            <tr>
+              <td>Pseudonym with Hidden Pid</td>
+              <td>`0xd9`, `0x5d`, and `0x08`</td>
+              <td><em>baseline</em> + signerBlind</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <table class="complex data">
+          <caption>Table 3 <em>Holder Add Derived: Inputs and such.</em> </caption>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Tasks</th>
+              <th>Inputs</th>
+              <th>Proof Generation Algorithm</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Baseline BBS</td>
+              <td>BBS derived proof generation from VC with base proof</td>
+              <td><em>baseline</em>: (from base proof serialization) bbsSignature, bbsHeader, publicKey, hmacKey, and mandatoryPointers; selectivePointers (holders choice)</td>
+              <td>BBS</td>
+            </tr>
+            <tr>
+              <td>Anonymous Holder Binding</td>
+              <td><em>baseline</em></td>
+              <td><em>baseline</em> + holder secret, prover blind (both known to holder), signer blind (included in base proof from issuer)</td>
+              <td>Blind BBS</td>
+            </tr>
+            <tr>
+              <td>Pseudonym with Issuer Pid</td>
+              <td><em>baseline</em> + Generate pseudonym</td>
+              <td><em>baseline</em> + verifier id (from verifier), pid (included in base from issuer)</td>
+              <td>Pseudonym BBS</td>
+            </tr>
+            <tr>
+              <td>Pseudonym with Hidden Pid</td>
+              <td><em>baseline</em> + Generate pseudonym</td>
+              <td><em>baseline</em> + pid, prover blind (both known to holder), signer blind (included in base from issuer), verifier id (from verifier)</td>
+              <td>Pseudonym/Blind BBS</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <table class="complex data">
+          <caption>Table 4 <em>Holder Add Derived: Headers and Serialization.</em> </caption>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Proof Header Bytes</th>
+              <th>Serialized Output</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Baseline BBS</td>
+              <td>`0xd9`, `0x5d`, and `0x03`</td>
+              <td><em>baseline</em>: bbsProof, compressedLabelMap, mandatoryIndexes, selectiveIndexes, presentationHeader</td>
+            </tr>
+            <tr>
+              <td>Anonymous Holder Binding</td>
+              <td>`0xd9`, `0x5d`, and `0x05`</td>
+              <td><em>baseline</em></td>
+            </tr>
+            <tr>
+              <td>Pseudonym with Issuer Pid </td>
+              <td>`0xd9`, `0x5d`, and `0x07`</td>
+              <td><em>baseline</em> + pseudonym</td>
+            </tr>
+            <tr>
+              <td>Pseudonym with Hidden Pid</td>
+              <td>`0xd9`, `0x5d`, and `0x09`</td>
+              <td><em>baseline</em> + pseudonym</td>
+            </tr>
+          </tbody>
+        </table>
+
+         <table class="complex data">
+          <caption>Table 5 <em>Verify Derived: Inputs and Algorithms.</em> </caption>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Inputs</th>
+              <th>Proof Verification Algorithm</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>BBS baseline</td>
+              <td><em>baseline</em>: (from derived proof serialization) bbsProof, compressedLabelMap, mandatoryIndexes, selectiveIndexes, presentationHeader</td>
+              <td>BBS</td>
+            </tr>
+            <tr>
+              <td>Anonymous Holder Binding</td>
+              <td><em>baseline</em></td>
+              <td>Blind BBS</td>
+            </tr>
+            <tr>
+              <td>Pseudonym with Issuer Pid</td>
+              <td><em>baseline</em> + verifier id (known to verifier),  pseudonym (included in derived proof)</td>
+              <td>Pseudonym BBS</td>
+            </tr>
+            <tr>
+              <td>Pseudonym with Hidden Pid</td>
+              <td><em>baseline</em> + verifier id (known to verifier), pseudonym (included in derived proof)</td>
+              <td>Pseudonym/Blind BBS</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
     </section>
     <section>
       <h2>Security Considerations</h2>

--- a/index.html
+++ b/index.html
@@ -785,7 +785,7 @@ produced as output, which contains the |bbsProof|, |labelMap|,
           <ol class="algorithm">
             <li>
 Initialize |bbsSignature|, |bbsHeader|, |publicKey|, |hmacKey|,
-|mandatoryPointers|, and the optional feature parameters |pid| and
+|mandatoryPointers|, |pid|, and
 |signer_blind| to the values of the associated properties in the object
 returned when calling the algorithm in Section
 <a href="#parsebaseproofvalue"></a>, passing the `proofValue` from `proof`.


### PR DESCRIPTION
This PR addresses issues:   https://github.com/w3c/vc-di-bbs/issues/153,  https://github.com/w3c/vc-di-bbs/issues/156 and also https://github.com/w3c/vc-di-bbs/issues/150 and https://github.com/w3c/vc-di-bbs/issues/157.

It does this by clarifying which optional feature, if any, is being used via an `featureOption` variable, feature specific base proof and derived proof header bytes, and extending procedure/function descriptions to clarify inputs/outputs. In addition *informative* summary tables have been added to the section describing the optional features. 

Note that some optional features are dependent on IETF APIs that are yet to be frozen. These have been notated.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-bbs/pull/158.html" title="Last updated on Apr 28, 2024, 4:09 PM UTC (bae66c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/158/49c52b5...Wind4Greg:bae66c2.html" title="Last updated on Apr 28, 2024, 4:09 PM UTC (bae66c2)">Diff</a>