### PR TITLE
Correct small typo DataIntegrityProof not DataIntegirtyProof.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1253,7 +1253,7 @@ object is produced as output.
 Let |proofConfig| be a clone of the |options| object.
             </li>
             <li>
-If |proofConfig|.|type| is not set to `DataIntegirtyProof` and/or
+If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
 |proofConfig|.|cryptosuite| is not set to `bbs-2023`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>


### PR DESCRIPTION
Addresses a small typo mentioned in this issue: https://github.com/w3c/vc-di-bbs/issues/154


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/vc-di-bbs/pull/159.html" title="Last updated on Apr 18, 2024, 4:03 PM UTC (cb298e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/159/4abda10...aljones15:cb298e8.html" title="Last updated on Apr 18, 2024, 4:03 PM UTC (cb298e8)">Diff</a>