### PR TITLE
Removed unused variable, Correct function reference.

### DIFF
--- a/index.html
+++ b/index.html
@@ -796,7 +796,7 @@ algorithm used in the signature algorithm, i.e., SHA-256.
             </li>
             <li>
 Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
-section <a href="#createshuffledidlabelmapfunction"></a> passing |hmac| as |HMAC|.
+section <a href="#createshuffledidlabelmapfunction"></a>, passing |hmac| as |HMAC|.
             </li>
             <li>
 Initialize |combinedPointers| to the concatenation of |mandatoryPointers|

--- a/index.html
+++ b/index.html
@@ -795,8 +795,8 @@ Initialize |hmac| to an HMAC API using |hmacKey|. The HMAC uses the same hash
 algorithm used in the signature algorithm, i.e., SHA-256.
             </li>
             <li>
-Initialize |labelMapFactoryFunction| to the result of calling the
-|createShuffledIdLabelMapFunction| algorithm passing |hmac| as |HMAC|.
+Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
+section <a href="#createshuffledidlabelmapfunction"></a> passing |hmac| as |HMAC|.
             </li>
             <li>
 Initialize |combinedPointers| to the concatenation of |mandatoryPointers|
@@ -1213,8 +1213,8 @@ object returned when calling the algorithm in Section
 <a href="#parsederivedproofvalue"></a>, passing |proofValue| from |proof|.
             </li>
             <li>
-Initialize |labelMapFactoryFunction| to the result of calling the
-"`createLabelMapFunction`" algorithm.
+Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
+section <a href="#createshuffledidlabelmapfunction"></a>.
             </li>
             <li>
 Initialize |nquads| to the result of calling the "`labelReplacementCanonicalize`"
@@ -1679,10 +1679,6 @@ To verify a derived proof, perform the following steps:
             <li>
 Let |unsecuredDocument| be a copy of |securedDocument| with
 the `proof` value removed.
-            </li>
-            <li>
-Let |proofConfig| be a copy of |securedDocument|.|proof| with `proofValue`
-removed.
             </li>
             <li>
 Let |proof| be the value of |securedDocument|.|proof|.


### PR DESCRIPTION
This PR addresses issues https://github.com/w3c/vc-di-bbs/issues/164 and https://github.com/w3c/vc-di-bbs/issues/163. It removes the unused variable *proofConfig* from the *Verify Derived Proof (bbs-2023)* procedure and updates and corrects references to the *createShuffledIdLabelMapFunction* function that is used and a "label map" in the *createDisclosureData* and *createVerifyData* procedures.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-bbs/pull/165.html" title="Last updated on May 13, 2024, 5:28 PM UTC (c391f95)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/165/c6a198c...Wind4Greg:c391f95.html" title="Last updated on May 13, 2024, 5:28 PM UTC (c391f95)">Diff</a>