### PR TITLE
Fix variable reference to "selectedIndexes". Add information on public key.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1191,7 +1191,7 @@ BBS-protected <a>verifiable credential</a>. The inputs include a JSON-LD
 document (|document|), a BBS disclosure proof (|proof|),
 and any custom JSON-LD API options (such as a document loader). A single
 <em>verify data</em> object value is produced as output containing the following
-fields: |bbsProof|, |proofHash|, |mandatoryHash|, |selectedIndexes|,
+fields: |bbsProof|, |proofHash|, |mandatoryHash|, |selectiveIndexes|,
 |presentationHeader|, |nonMandatory|, |featureOption|, and, possibly,
 |pseudonym|.
           </p>
@@ -1692,7 +1692,7 @@ the `proof` value removed.
 Let |proof| be the value of |securedDocument|.|proof|.
             </li>
             <li>
-Initialize |bbsProof|, |proofHash|, |mandatoryHash|, |selectedIndexes|,
+Initialize |bbsProof|, |proofHash|, |mandatoryHash|, |selectiveIndexes|,
 |presentationHeader|, |nonMandatory|, |featureOption|, and, possibly,
 |pseudonym|, to the values associated
 with their property names in the object returned when calling the algorithm in
@@ -1714,7 +1714,7 @@ applying the verification algorithm `ProofVerify(PK, proof, header, ph,
 disclosed_messages, disclosed_indexes)` of [[CFRG-BBS-SIGNATURE]] with `PK` set
 as the public key of the original issuer, `proof` set as `bbsProof`, `header`
 set as `bbsHeader`, `disclosed_messages` set as `disclosedMessages`, `ph` set as
-`presentationHeader`, and `disclosed_indexes` set as `selectedIndexes`.
+`presentationHeader`, and `disclosed_indexes` set as `selectiveIndexes`.
               </li>
               <li>
 If the |featureOption| equals `"anonymous_holder_binding"`,

--- a/index.html
+++ b/index.html
@@ -1677,6 +1677,14 @@ To verify a derived proof, perform the following steps:
 
           <ol class="algorithm">
             <li>
+Let |publicKeyBytes| be the result of retrieving the
+public key bytes associated with the
+|proof|.|verificationMethod| value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Retrieve Verification Method</a>.
+            </li>
+            <li>
 Let |unsecuredDocument| be a copy of |securedDocument| with
 the `proof` value removed.
             </li>
@@ -1706,7 +1714,7 @@ applying the verification algorithm `ProofVerify(PK, proof, header, ph,
 disclosed_messages, disclosed_indexes)` of [[CFRG-BBS-SIGNATURE]] with `PK` set
 as the public key of the original issuer, `proof` set as `bbsProof`, `header`
 set as `bbsHeader`, `disclosed_messages` set as `disclosedMessages`, `ph` set as
-`presentationHeader`, and `disclosed_indexes` set as `selectiveIndexes`.
+`presentationHeader`, and `disclosed_indexes` set as `selectedIndexes`.
               </li>
               <li>
 If the |featureOption| equals `"anonymous_holder_binding"`,


### PR DESCRIPTION
This editorial PR addresses issue https://github.com/w3c/vc-di-bbs/issues/166 by fixing the name of the variable used and adding information on how to obtain information on the public key used in the signature.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-bbs/pull/167.html" title="Last updated on Jun 17, 2024, 4:46 PM UTC (2f7d864)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/167/b64ef10...Wind4Greg:2f7d864.html" title="Last updated on Jun 17, 2024, 4:46 PM UTC (2f7d864)">Diff</a>