### PR TITLE
Remove the 'Universal' from the RDFC references.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1261,7 +1261,7 @@ possibly |pseudonym|.
 
         <p>
 The `bbs-2023` cryptographic suite takes an input document, canonicalizes
-the document using the Universal RDF Dataset Canonicalization Algorithm
+the document using the RDF Dataset Canonicalization Algorithm
 [[RDF-CANON]], and then applies a number of transformations and cryptographic
 operations resulting in the production of a data integrity proof. The algorithms
 in this section also include the verification of such a data integrity proof.
@@ -1476,7 +1476,7 @@ Set |proofConfig|.|@context| to
 |unsecuredDocument|.|@context|.
             </li>
             <li>
-Let |canonicalProofConfig| be the result of applying the Universal RDF Dataset
+Let |canonicalProofConfig| be the result of applying the RDF Dataset
 Canonicalization Algorithm [[RDF-CANON]] to the |proofConfig|.
             </li>
             <li>


### PR DESCRIPTION
This is the same issue as https://github.com/w3c/vc-di-eddsa/issues/78.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/pull/169.html" title="Last updated on Jun 9, 2024, 8:42 AM UTC (cc724f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/169/c6a198c...cc724f3.html" title="Last updated on Jun 9, 2024, 8:42 AM UTC (cc724f3)">Diff</a>