### PR TITLE
Remove unnecessary input from Base Proof Serialization procedure

### DIFF
--- a/index.html
+++ b/index.html
@@ -1500,16 +1500,13 @@ in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
 <a data-cite="vc-data-integrity#algorithms">
 Section 4: Algorithms</a>. Required inputs are
 cryptographic hash data (|hashData|),
-<em>proof options</em> (|options|), |featureOption|, and, if required,
+|featureOption|, and, if required,
 |commitment_with_proof|.
 If |featureOption| is set to `"anonymous_holder_binding"` or
 `"pseudonym_hidden_pid"`, the
 |commitment_with_proof| input MUST be supplied; if not supplied, an error SHOULD be
 returned.
-The <em>proof options</em> MUST contain a type identifier for the
-<a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and MAY contain a cryptosuite
-identifier (|cryptosuite|). A single <em>digital proof</em> value
+A single <em>digital proof</em> value
 represented as series of bytes is produced as output.
           </p>
 


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-bbs/issues/172. It removes the unnecessary *proof options* input from the *Base Proof Serialization (bbs-2023)* procedure. This information is checked and used prior to this procedure and hence can be removed from this procedure.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-bbs/pull/173.html" title="Last updated on Jun 24, 2024, 4:03 PM UTC (70fb96d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/173/f1de019...Wind4Greg:70fb96d.html" title="Last updated on Jun 24, 2024, 4:03 PM UTC (70fb96d)">Diff</a>