### PR TITLE
Unify Error Handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1166,8 +1166,8 @@ If the |decodedProofValue| starts with the header bytes `0xd9`, `0x5d`, and
 Initialize `components` to an array that is the result of CBOR-decoding the
 bytes that follow the three-byte BBS disclosure proof header. If the result
 is not an array of five or six elements —
-a byte array, a map of integers to integers, an
-array of integers, another array of integers, and one or two byte arrays;
+a byte array, a map of integers to integers,
+two arrays of integers, and one or two byte arrays;
 an error MUST be raised and SHOULD convey an error type of
 `PROOF_VERIFICATION_ERROR`.
             </li>

--- a/index.html
+++ b/index.html
@@ -693,8 +693,9 @@ Ensure the `proofValue` string starts with
   <bdi lang="en"><code title="LATIN SMALL LETTER U">u</code></bdi>
   (<code class="codepoint">U+0075</code>
   <code class="uname">LATIN SMALL LETTER U</code>)</span>,
-indicating that it is a `multibase-base64url-no-pad-encoded` value, and throw
-an error if it does not.
+indicating that it is a `multibase-base64url-no-pad-encoded` value, and if it
+does not an error MUST be raised and SHOULD convey an error type of
+`PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
 Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
@@ -721,8 +722,9 @@ If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x08`, set
 |featureOption| to `"pseudonym_hidden_pid"`.
                 </li>
                 <li>
-If the |decodedProofValue| starts with any other three byte sequence, throw an
-error.
+If the |decodedProofValue| starts with any other three byte sequence,
+an error MUST be raised and SHOULD convey an error type of
+`PROOF_VERIFICATION_ERROR`.
                 </li>
               </ol>
 
@@ -1130,8 +1132,9 @@ Ensure the `proofValue` string starts with
   <bdi lang="en"><code title="LATIN SMALL LETTER U">u</code></bdi>
   (<code class="codepoint">U+0075</code>,
   <code class="uname">LATIN SMALL LETTER U</code>)</span>, indicating that
-it is a `multibase-base64url-no-pad-encoded` value, and throw an error if it does
-not.
+it is a `multibase-base64url-no-pad-encoded` value, and if it does
+not an error MUST be raised and SHOULD convey an error type of
+`PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
 Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
@@ -1165,7 +1168,8 @@ bytes that follow the three-byte BBS disclosure proof header. Ensure the result
 is an array of five or six elements —
 a byte array, a map of integers to integers, an
 array of integers, another array of integers, and one or two byte arrays;
-otherwise, throw an error.
+otherwise, an error MUST be raised and SHOULD convey an error type of
+`PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
 Replace the second element in `components` using the result of calling the
@@ -1463,13 +1467,13 @@ Let |proofConfig| be a clone of the |options| object.
             </li>
             <li>
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
-|proofConfig|.|cryptosuite| is not set to `bbs-2023`, an
-`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+|proofConfig|.|cryptosuite| is not set to `bbs-2023`, an error MUST be raised
+and SHOULD convey an error type of `PROOF_GENERATION_ERROR`.
             </li>
             <li>
 If |proofConfig|.|created| is set and if the value is not a
-valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
-raised.
+valid [[XMLSCHEMA11-2]] datetime, an error MUST be raised and SHOULD convey an
+error type of `PROOF_GENERATION_ERROR`.
             </li>
             <li>
 Set |proofConfig|.|@context| to
@@ -1504,8 +1508,9 @@ cryptographic hash data (|hashData|),
 |commitment_with_proof|.
 If |featureOption| is set to `"anonymous_holder_binding"` or
 `"pseudonym_hidden_pid"`, the
-|commitment_with_proof| input MUST be supplied; if not supplied, an error SHOULD be
-returned.
+|commitment_with_proof| input MUST be supplied; if not supplied,
+an error MUST be raised and SHOULD convey an error type of
+`PROOF_GENERATION_ERROR`.
 The <em>proof options</em> MUST contain a type identifier for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
 cryptographic suite</a> (|type|) and MAY contain a cryptosuite

--- a/index.html
+++ b/index.html
@@ -688,13 +688,13 @@ parameter "pid" or
 
           <ol class="algorithm">
             <li>
-Ensure the `proofValue` string starts with
+If the `proofValue` string does not start with
 <span class="codepoint" translate="no">
   <bdi lang="en"><code title="LATIN SMALL LETTER U">u</code></bdi>
   (<code class="codepoint">U+0075</code>
   <code class="uname">LATIN SMALL LETTER U</code>)</span>,
-indicating that it is a `multibase-base64url-no-pad-encoded` value, and if it
-does not an error MUST be raised and SHOULD convey an error type of
+indicating that it is a `multibase-base64url-no-pad-encoded` value,
+an error MUST be raised and SHOULD convey an error type of
 `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
@@ -1127,13 +1127,13 @@ contains a set of six or seven elements, having the names "bbsProof",
 
           <ol class="algorithm">
             <li>
-Ensure the `proofValue` string starts with
+If the `proofValue` string does not start with
 <span class="codepoint" translate="no">
   <bdi lang="en"><code title="LATIN SMALL LETTER U">u</code></bdi>
   (<code class="codepoint">U+0075</code>,
   <code class="uname">LATIN SMALL LETTER U</code>)</span>, indicating that
-it is a `multibase-base64url-no-pad-encoded` value, and if it does
-not an error MUST be raised and SHOULD convey an error type of
+it is a `multibase-base64url-no-pad-encoded` value,
+an error MUST be raised and SHOULD convey an error type of
 `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
@@ -1164,11 +1164,11 @@ If the |decodedProofValue| starts with the header bytes `0xd9`, `0x5d`, and
 
             <li>
 Initialize `components` to an array that is the result of CBOR-decoding the
-bytes that follow the three-byte BBS disclosure proof header. Ensure the result
-is an array of five or six elements —
+bytes that follow the three-byte BBS disclosure proof header. If the result
+is not an array of five or six elements —
 a byte array, a map of integers to integers, an
 array of integers, another array of integers, and one or two byte arrays;
-otherwise, an error MUST be raised and SHOULD convey an error type of
+an error MUST be raised and SHOULD convey an error type of
 `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -695,7 +695,7 @@ If the `proofValue` string does not start with
   <code class="uname">LATIN SMALL LETTER U</code>)</span>,
 indicating that it is a `multibase-base64url-no-pad-encoded` value,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_VERIFICATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
             </li>
             <li>
 Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
@@ -724,7 +724,7 @@ If the |decodedProofValue| starts with the bytes `0xd9`, `0x5d`, and `0x08`, set
                 <li>
 If the |decodedProofValue| starts with any other three byte sequence,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_VERIFICATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
                 </li>
               </ol>
 
@@ -1134,7 +1134,7 @@ If the `proofValue` string does not start with
   <code class="uname">LATIN SMALL LETTER U</code>)</span>, indicating that
 it is a `multibase-base64url-no-pad-encoded` value,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_VERIFICATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
             </li>
             <li>
 Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
@@ -1169,7 +1169,7 @@ is not an array of five or six elements —
 a byte array, a map of integers to integers,
 two arrays of integers, and one or two byte arrays;
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_VERIFICATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
             </li>
             <li>
 Replace the second element in `components` using the result of calling the
@@ -1468,12 +1468,14 @@ Let |proofConfig| be a clone of the |options| object.
             <li>
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
 |proofConfig|.|cryptosuite| is not set to `bbs-2023`, an error MUST be raised
-and SHOULD convey an error type of `PROOF_GENERATION_ERROR`.
+and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 If |proofConfig|.|created| is set and if the value is not a
 valid [[XMLSCHEMA11-2]] datetime, an error MUST be raised and SHOULD convey an
-error type of `PROOF_GENERATION_ERROR`.
+error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 Set |proofConfig|.|@context| to
@@ -1510,7 +1512,7 @@ If |featureOption| is set to `"anonymous_holder_binding"` or
 `"pseudonym_hidden_pid"`, the
 |commitment_with_proof| input MUST be supplied; if not supplied,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_GENERATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
 The <em>proof options</em> MUST contain a type identifier for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
 cryptographic suite</a> (|type|) and MAY contain a cryptosuite


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-bbs/issues/168.

Update to use common error codes, use appropriate error handling language, and add error codes where required.

See issue https://github.com/w3c/vc-di-eddsa/issues/82 for discussion of common error codes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-bbs/pull/174.html" title="Last updated on Jun 30, 2024, 4:41 PM UTC (3032009)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/174/72feec7...Wind4Greg:3032009.html" title="Last updated on Jun 30, 2024, 4:41 PM UTC (3032009)">Diff</a>