### PR TITLE
Remove proof options from base proof serialization again.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1513,11 +1513,8 @@ If |featureOption| is set to `"anonymous_holder_binding"` or
 |commitment_with_proof| input MUST be supplied; if not supplied,
 an error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
-The <em>proof options</em> MUST contain a type identifier for the
-<a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and MAY contain a cryptosuite
-identifier (|cryptosuite|). A single <em>digital proof</em> value
-represented as series of bytes is produced as output.
+A single <em>digital proof</em> value represented as series of bytes is produced
+as output.
           </p>
 
           <ol class="algorithm">


### PR DESCRIPTION
Corrects a potential regress of https://github.com/w3c/vc-di-bbs/pull/173/files

Removes the proofOptions section from base proof serialization again.
Interestingly the proofOptions did not need to be removed from the Algorithms section again.