### PR TITLE
Improve normative statement WRT to derived proofValue element count.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1157,7 +1157,8 @@ Initialize `components` to an array that is the result of CBOR-decoding the
 bytes that follow the three-byte BBS disclosure proof header. If the result
 is not an array of five, six, or seven elements —
 a byte array, a map of integers to integers,
-two arrays of integers, and one or two byte arrays;
+two arrays of integers, one or two byte arrays, and an optional element
+determined by the featureOption;
 an error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
             </li>

--- a/index.html
+++ b/index.html
@@ -1158,7 +1158,7 @@ bytes that follow the three-byte BBS disclosure proof header. If the result
 is not an array of five, six, or seven elements —
 a byte array, a map of integers to integers,
 two arrays of integers, one or two byte arrays, and an optional element
-determined by the featureOption;
+determined by the featureOption —
 an error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
             </li>


### PR DESCRIPTION
This is a draft because this addition could be wrong.
The current wording in the spec leaves the 7th element mentioned in the normative statement around derived proof values ambiguous. This PR speculates that the 7th element is an optional element in components included by some featureOptions such as blind and pseudonym algorithms.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/vc-di-bbs/pull/188.html" title="Last updated on Oct 23, 2024, 2:57 PM UTC (b1819b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/188/ad66d38...aljones15:b1819b3.html" title="Last updated on Oct 23, 2024, 2:57 PM UTC (b1819b3)">Diff</a>