### PR TITLE
Fix missing input in Base Proof Configuration procedure.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1445,8 +1445,10 @@ that is used as input to the
 
           <p>
 The required inputs to this algorithm are <em>proof options</em>
-(|options|). The <em>proof options</em> MUST contain a type identifier
-for the
+(|options|) and the
+<a data-cite="vc-data-integrity#dfn-unsecured-data-document">unsecured data
+document</a> (|unsecuredDocument|). The <em>proof options</em> MUST contain a
+type identifier for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
 cryptographic suite</a> (|type|) and MUST contain a cryptosuite
 identifier (|cryptosuite|). A <em>proof configuration</em>


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-bbs/issues/189. The input is used in the procedure but not mentioned at the beginning of the procedure with the other inputs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-bbs/pull/193.html" title="Last updated on Nov 12, 2024, 7:18 PM UTC (ab33668)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/193/ad66d38...Wind4Greg:ab33668.html" title="Last updated on Nov 12, 2024, 7:18 PM UTC (ab33668)">Diff</a>