### PR TITLE
Editorial: Fix href for Blind BBS Signatures

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,8 +169,8 @@
           "CFRG-Blind-BBS-Signature": {
             title: "Blind BBS Signatures",
             authors: ["V. Kalos", "G. Bernstein"],
-            date: "2024",
-            href: "https://www.ietf.org/archive/id/draft-kalos-bbs-blind-signatures-03.html#name-proof-generation"
+            date: "2025",
+            href: "https://www.ietf.org/archive/id/draft-irtf-cfrg-bbs-blind-signatures-02.html#name-proof-generation"
           },
           "CFRG-Pseudonym-BBS-Signature": {
             title: "BBS per Verifier Linkability",

--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
             title: "Blind BBS Signatures",
             authors: ["V. Kalos", "G. Bernstein"],
             date: "2024",
-            href: "https://www.ietf.org/archive/id/draft-kalos-bbs-blind-signatures-00.html#name-proof-generationhttps://www.ietf.org/archive/id/draft-kalos-bbs-blind-signatures-03.html"
+            href: "https://www.ietf.org/archive/id/draft-kalos-bbs-blind-signatures-03.html#name-proof-generation"
           },
           "CFRG-Pseudonym-BBS-Signature": {
             title: "BBS per Verifier Linkability",


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/pull/205.html" title="Last updated on Feb 3, 2026, 1:33 PM UTC (0b3309f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-bbs/205/e33bf8b...0b3309f.html" title="Last updated on Feb 3, 2026, 1:33 PM UTC (0b3309f)">Diff</a>